### PR TITLE
Add home page with collapsible sidebar

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -31,7 +31,8 @@ class AuthController extends Controller
         // Iniciamos sesión automáticamente
         Auth::login($user);
 
-        return redirect('/');
+        // Redirigimos al usuario a la página de inicio
+        return redirect('/home');
     }
 
     /**
@@ -50,7 +51,8 @@ class AuthController extends Controller
             // Regeneramos la sesión por seguridad
             $request->session()->regenerate();
 
-            return redirect()->intended('/');
+            // Redireccionamos al destino previsto o a la página de inicio
+            return redirect()->intended('/home');
         }
 
         // Si falló la autenticación, regresamos con un error

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name', 'Laravel') }}</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    {{-- Script sencillo para mostrar u ocultar el sidebar --}}
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const button = document.getElementById('sidebar-toggle');
+            const sidebar = document.getElementById('sidebar');
+            if (button && sidebar) {
+                button.addEventListener('click', function () {
+                    sidebar.classList.toggle('-translate-x-full');
+                });
+            }
+        });
+    </script>
+</head>
+<body class="flex min-h-screen bg-gray-100">
+    {{-- Barra lateral colapsable --}}
+    <aside id="sidebar" class="bg-gray-800 text-white w-64 transform md:translate-x-0 -translate-x-full transition-transform duration-200 ease-in-out fixed md:relative inset-y-0 left-0">
+        <div class="p-4 font-bold text-lg">Menú</div>
+        <nav class="mt-5">
+            <ul>
+                <li class="px-4 py-2 hover:bg-gray-700"><a href="#">Dashboard</a></li>
+                <li class="px-4 py-2 hover:bg-gray-700"><a href="#">Socios</a></li>
+                <li class="px-4 py-2 hover:bg-gray-700"><a href="#">Prestamos</a></li>
+                <li class="px-4 py-2 hover:bg-gray-700"><a href="#">Reportes</a></li>
+                <li class="px-4 py-2 hover:bg-gray-700"><a href="#">Configuraciones</a></li>
+            </ul>
+        </nav>
+    </aside>
+
+    {{-- Contenedor principal de la aplicación --}}
+    <div class="flex-1 flex flex-col ml-0 md:ml-64">
+        <header class="bg-white shadow p-4 md:hidden">
+            <button id="sidebar-toggle" class="text-gray-600">
+                &#9776;
+            </button>
+        </header>
+        <main class="p-6">
+            {{ $slot }}
+        </main>
+    </div>
+</body>
+</html>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,0 +1,4 @@
+<x-layouts.app>
+    {{-- Contenido principal de la página de inicio --}}
+    <h1 class="text-2xl font-bold">Bienvenido</h1>
+</x-layouts.app>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,3 +14,6 @@ Route::view('/register', 'auth.register')->name('register'); // Muestra el formu
 Route::post('/register', [AuthController::class, 'register'])->name('register.submit'); // Procesa el registro de usuario
 
 Route::post('/logout', [AuthController::class, 'logout'])->name('logout'); // Cierra la sesión
+
+// Ruta protegida que muestra la página de inicio
+Route::view('/home', 'home')->middleware('auth')->name('home');


### PR DESCRIPTION
## Summary
- add new authenticated layout with collapsible sidebar
- redirect logins/registrations to `/home`
- create protected `/home` route and home view

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_685c68e1da1c8333b10a17449aa41c7f