### PR TITLE
Admin management suite: withdrawals, investments, RLS, edit/delete everywhere, sidebar nav

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,11 @@ Sistema financiero cerrado para gestionar los ahorros, préstamos, eventos y mul
 - `pnpm build` — Build de producción
 - `npx supabase start` — Iniciar Supabase local (Studio: http://127.0.0.1:54323)
 - `npx supabase stop` — Detener Supabase local
-- `npx supabase db reset` — Resetear DB local (re-aplica migraciones + seed)
 - `npx supabase migration new <nombre>` — Crear nueva migración
+- `npx supabase migration up` — **Aplicar solo migraciones pendientes** (preserva datos). Úsalo en el día a día.
+- `npx supabase db reset` — Resetear DB local (borra todo, re-aplica migraciones + seed). Úsalo solo cuando cambies el seed o modifiques una migración ya aplicada.
+
+**Regla:** nunca editar una migración ya aplicada. Si necesitas un cambio, crear una nueva migración (`alter table`, etc.).
 
 ## Arquitectura y Convenciones
 - Código fuertemente tipado con interfaces explícitas en TypeScript.
@@ -58,10 +61,12 @@ Tablas en PostgreSQL (Supabase), relacionadas mediante UUIDs:
 - `loans` — (id, profile_id, guarantor_id, requested_amount, interest_rate, installments, status, created_at). Status: `pending`, `active`, `paid`, `defaulted`, `rejected`.
 - `loan_payments` — (id, loan_id, amount, payment_date, created_at).
 - `teams` — (id, name, term, created_at).
-- `team_members` — (team_id, profile_id). PK compuesta.
+- `team_members` — (team_id, profile_id, role_title). PK compuesta. `role_title` es opcional y representa el cargo dentro del equipo (ej. "Presidente", "Tesorero", "Secretario").
 - `activities` — (id, team_id, name, activity_date, costs, net_profits, created_at).
 - `meetings` — (id, topic, meeting_date, created_at).
 - `penalties` — (id, profile_id, meeting_id, reason, amount, status, created_at). Reason: `absence`, `late_arrival`, `other`. Status: `pending`, `paid`, `deducted_from_savings`.
+- `withdrawals` — (id, profile_id, amount, status, created_at). Status: `pending`, `approved`, `rejected`. Representa solicitudes de retiro de ahorros.
+- `investments` — (id, name, invested_amount, annual_interest_rate, start_date, end_date, status, actual_return, created_at). Status: `active`, `completed`. `actual_return` se llena cuando se finaliza la inversión y representa el rendimiento real obtenido (entra al Capital en Caja).
 
 ## Reglas de Negocio y Estatutos (ESTRICTO)
 

--- a/app/components/ConfirmModal.vue
+++ b/app/components/ConfirmModal.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+defineProps<{
+  visible: boolean
+  title: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'danger' | 'warning'
+  loading?: boolean
+}>()
+
+const emit = defineEmits<{
+  confirm: []
+  cancel: []
+}>()
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="visible"
+        class="fixed inset-0 z-50 flex items-center justify-center px-4"
+      >
+        <div class="absolute inset-0 bg-black/60" @click="emit('cancel')" />
+
+        <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+          <div class="flex items-start gap-4 mb-5">
+            <div
+              class="h-12 w-12 rounded-xl flex items-center justify-center shrink-0"
+              :class="variant === 'warning' ? 'bg-yellow-500/20' : 'bg-red-500/20'"
+            >
+              <svg
+                class="h-6 w-6"
+                :class="variant === 'warning' ? 'text-yellow-400' : 'text-red-400'"
+                fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+              </svg>
+            </div>
+            <div class="flex-1 min-w-0">
+              <h3 class="text-lg font-bold text-white">{{ title }}</h3>
+              <p class="text-sm text-gray-400 mt-1">{{ message }}</p>
+            </div>
+          </div>
+
+          <div class="flex gap-2">
+            <button
+              type="button"
+              class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+              :disabled="loading"
+              @click="emit('cancel')"
+            >
+              {{ cancelLabel ?? 'Cancelar' }}
+            </button>
+            <button
+              type="button"
+              class="flex-1 rounded-lg py-2.5 text-sm font-semibold text-white transition disabled:opacity-50 disabled:cursor-not-allowed"
+              :class="variant === 'warning'
+                ? 'bg-yellow-600 hover:bg-yellow-500'
+                : 'bg-red-600 hover:bg-red-500'"
+              :disabled="loading"
+              @click="emit('confirm')"
+            >
+              {{ loading ? 'Procesando...' : (confirmLabel ?? 'Eliminar') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/app/components/LoanPaymentModal.vue
+++ b/app/components/LoanPaymentModal.vue
@@ -44,32 +44,18 @@ async function handleSubmit() {
     return
   }
 
-  // 2. Verificar si el préstamo se pagó completamente
+  // 2. Verificar si el préstamo se pagó completamente (RPC con SECURITY DEFINER
+  //    porque con RLS solo el admin puede UPDATE `loans` directamente).
+  await supabase.rpc('mark_loan_paid_if_complete', { p_loan_id: props.loanId })
+
   const { data: loan } = await supabase
     .from('loans')
-    .select('requested_amount, interest_rate')
+    .select('status')
     .eq('id', props.loanId)
     .single()
 
-  const { data: payments } = await supabase
-    .from('loan_payments')
-    .select('amount')
-    .eq('loan_id', props.loanId)
-
-  if (loan && payments) {
-    const totalDue = Math.round(loan.requested_amount * (1 + loan.interest_rate / 100))
-    const totalPaid = payments.reduce((sum, p) => sum + p.amount, 0)
-
-    if (totalPaid >= totalDue) {
-      await supabase
-        .from('loans')
-        .update({ status: 'paid' })
-        .eq('id', props.loanId)
-
-      toast.success('Préstamo pagado en su totalidad.')
-    } else {
-      toast.success('Pago registrado correctamente.')
-    }
+  if (loan?.status === 'paid') {
+    toast.success('Préstamo pagado en su totalidad.')
   } else {
     toast.success('Pago registrado correctamente.')
   }

--- a/app/components/WithdrawalModal.vue
+++ b/app/components/WithdrawalModal.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+const props = defineProps<{
+  visible: boolean
+  availableSavings: number
+}>()
+
+const emit = defineEmits<{
+  close: []
+  saved: []
+}>()
+
+const supabase = useSupabase()
+const toast = useToast()
+
+const amount = ref<number | null>(null)
+const submitting = ref(false)
+
+const exceedsAvailable = computed(() =>
+  amount.value !== null && amount.value > props.availableSavings,
+)
+
+function formatCOP(value: number): string {
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(value)
+}
+
+async function handleSubmit() {
+  if (!amount.value || amount.value <= 0) return
+
+  if (amount.value > props.availableSavings) {
+    toast.error(`El monto supera tu ahorro disponible (${formatCOP(props.availableSavings)}).`)
+    return
+  }
+
+  submitting.value = true
+
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    submitting.value = false
+    return
+  }
+
+  const { error } = await supabase.from('withdrawals').insert({
+    profile_id: user.id,
+    amount: amount.value,
+    status: 'pending',
+  })
+
+  submitting.value = false
+
+  if (error) {
+    toast.error('Error al registrar el retiro. Intenta de nuevo.')
+    return
+  }
+
+  toast.success('Solicitud de retiro enviada. En espera de aprobación del administrador.')
+  amount.value = null
+  emit('saved')
+  emit('close')
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="visible"
+        class="fixed inset-0 z-50 flex items-center justify-center px-4"
+      >
+        <div
+          class="absolute inset-0 bg-black/60"
+          @click="emit('close')"
+        />
+
+        <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+          <div class="flex items-center justify-between mb-6">
+            <h2 class="text-xl font-bold text-white">Solicitar Retiro</h2>
+            <button
+              class="text-gray-500 hover:text-white transition"
+              @click="emit('close')"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+              </svg>
+            </button>
+          </div>
+
+          <div class="mb-5 rounded-lg bg-gray-800/50 px-4 py-3">
+            <p class="text-xs text-gray-400 uppercase tracking-wider">Ahorro disponible</p>
+            <p class="text-xl font-bold text-emerald-400 mt-1">{{ formatCOP(availableSavings) }}</p>
+          </div>
+
+          <form @submit.prevent="handleSubmit" class="space-y-5">
+            <div>
+              <label for="withdrawal-amount" class="block text-sm font-medium text-gray-300 mb-1">
+                Monto a retirar (COP)
+              </label>
+              <input
+                id="withdrawal-amount"
+                v-model.number="amount"
+                type="number"
+                required
+                min="1"
+                :max="availableSavings"
+                step="1"
+                placeholder="50000"
+                class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+              />
+              <p
+                v-if="exceedsAvailable"
+                class="text-xs text-red-400 mt-1"
+              >
+                El monto supera tu ahorro disponible.
+              </p>
+            </div>
+
+            <button
+              type="submit"
+              :disabled="submitting || exceedsAvailable || !amount"
+              class="w-full rounded-lg bg-emerald-600 py-2.5 text-white font-semibold hover:bg-emerald-500 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-gray-900 transition disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {{ submitting ? 'Enviando...' : 'Enviar Solicitud' }}
+            </button>
+          </form>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -5,7 +5,7 @@ const route = useRoute()
 
 const profileName = ref('')
 const profileRole = ref('')
-const mobileMenuOpen = ref(false)
+const sidebarOpen = ref(false)
 const userMenuOpen = ref(false)
 
 function closeUserMenu() {
@@ -34,25 +34,52 @@ interface NavItem {
   to: string
   label: string
   icon: string
-  adminOnly?: boolean
 }
 
-const navItems: NavItem[] = [
-  { to: '/dashboard', label: 'Inicio', icon: 'home' },
-  { to: '/prestamos', label: 'Préstamos', icon: 'banknotes' },
-  { to: '/admin', label: 'Panel Admin', icon: 'shield', adminOnly: true },
-  { to: '/admin/reuniones', label: 'Reuniones', icon: 'calendar', adminOnly: true },
-  { to: '/admin/actividades', label: 'Actividades', icon: 'users', adminOnly: true },
-  { to: '/admin/balance', label: 'Balance', icon: 'chart', adminOnly: true },
+interface NavSection {
+  title: string
+  adminOnly?: boolean
+  items: NavItem[]
+}
+
+const navSections: NavSection[] = [
+  {
+    title: 'Principal',
+    items: [
+      { to: '/dashboard', label: 'Inicio', icon: 'home' },
+      { to: '/prestamos', label: 'Préstamos', icon: 'banknotes' },
+    ],
+  },
+  {
+    title: 'Fondo',
+    items: [
+      { to: '/junta', label: 'Junta Directiva', icon: 'users' },
+      { to: '/estatutos', label: 'Estatutos', icon: 'book' },
+    ],
+  },
+  {
+    title: 'Administración',
+    adminOnly: true,
+    items: [
+      { to: '/admin', label: 'Panel', icon: 'shield' },
+      { to: '/admin/miembros', label: 'Miembros', icon: 'users' },
+      { to: '/admin/retiros', label: 'Retiros', icon: 'banknotes' },
+      { to: '/admin/reuniones', label: 'Reuniones', icon: 'calendar' },
+      { to: '/admin/actividades', label: 'Actividades', icon: 'sparkles' },
+      { to: '/admin/inversiones', label: 'Inversiones', icon: 'trending' },
+      { to: '/admin/balance', label: 'Balance', icon: 'chart' },
+    ],
+  },
 ]
 
-const visibleNavItems = computed(() =>
-  navItems.filter(item => !item.adminOnly || profileRole.value === 'admin')
+const visibleSections = computed(() =>
+  navSections.filter(s => !s.adminOnly || profileRole.value === 'admin'),
 )
 
 function isActive(to: string): boolean {
   if (to === '/dashboard') return route.path === '/dashboard'
-  return route.path.startsWith(to)
+  if (to === '/admin') return route.path === '/admin'
+  return route.path === to || route.path.startsWith(to + '/')
 }
 
 onMounted(async () => {
@@ -71,6 +98,11 @@ onMounted(async () => {
   }
 })
 
+// Cerrar sidebar al navegar en móvil
+watch(() => route.path, () => {
+  sidebarOpen.value = false
+})
+
 async function handleLogout() {
   await supabase.auth.signOut()
   await router.push('/login')
@@ -79,83 +111,160 @@ async function handleLogout() {
 
 <template>
   <div class="min-h-screen bg-gray-950">
-    <!-- Navbar -->
-    <nav class="bg-gray-900/80 backdrop-blur-md border-b border-gray-800 sticky top-0 z-50">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex items-center justify-between h-16">
-          <!-- Logo -->
-          <NuxtLink to="/dashboard" class="flex items-center gap-2.5 group">
-            <div class="w-8 h-8 bg-emerald-500 rounded-lg flex items-center justify-center group-hover:bg-emerald-400 transition">
-              <svg class="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+    <!-- ==================== SIDEBAR ==================== -->
+    <aside
+      class="fixed inset-y-0 left-0 z-40 w-64 bg-gray-900 border-r border-gray-800 transform transition-transform duration-200 lg:translate-x-0"
+      :class="sidebarOpen ? 'translate-x-0' : '-translate-x-full'"
+    >
+      <!-- Logo -->
+      <div class="h-16 flex items-center justify-between px-5 border-b border-gray-800">
+        <NuxtLink to="/dashboard" class="flex items-center gap-2.5 group">
+          <div class="w-9 h-9 bg-gradient-to-br from-emerald-400 to-emerald-600 rounded-xl flex items-center justify-center shadow-lg shadow-emerald-500/20 group-hover:shadow-emerald-500/40 transition">
+            <svg class="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <div class="flex flex-col leading-tight">
+            <span class="text-base font-bold text-white tracking-tight">FODAF</span>
+            <span class="text-[10px] text-gray-500 uppercase tracking-widest">Fondo Familiar</span>
+          </div>
+        </NuxtLink>
+        <button
+          class="lg:hidden p-1.5 rounded-lg text-gray-400 hover:text-white hover:bg-gray-800 transition"
+          @click="sidebarOpen = false"
+        >
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Nav sections -->
+      <nav class="flex-1 overflow-y-auto py-5 px-3 space-y-6" style="max-height: calc(100vh - 4rem);">
+        <div v-for="section in visibleSections" :key="section.title">
+          <p class="px-3 mb-2 text-[10px] font-semibold text-gray-500 uppercase tracking-widest">
+            {{ section.title }}
+          </p>
+          <div class="space-y-1">
+            <NuxtLink
+              v-for="item in section.items"
+              :key="item.to"
+              :to="item.to"
+              class="group relative flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-all"
+              :class="isActive(item.to)
+                ? 'bg-emerald-500/10 text-emerald-400'
+                : 'text-gray-400 hover:text-white hover:bg-gray-800/60'"
+            >
+              <span
+                v-if="isActive(item.to)"
+                class="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-0.5 bg-emerald-400 rounded-r-full"
+              />
+              <!-- Icons -->
+              <svg v-if="item.icon === 'home'" class="w-[18px] h-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+              </svg>
+              <svg v-else-if="item.icon === 'banknotes'" class="w-[18px] h-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />
+              </svg>
+              <svg v-else-if="item.icon === 'users'" class="w-[18px] h-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
+              </svg>
+              <svg v-else-if="item.icon === 'book'" class="w-[18px] h-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+              </svg>
+              <svg v-else-if="item.icon === 'shield'" class="w-[18px] h-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+              </svg>
+              <svg v-else-if="item.icon === 'calendar'" class="w-[18px] h-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 9v9.75" />
+              </svg>
+              <svg v-else-if="item.icon === 'sparkles'" class="w-[18px] h-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.847.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z" />
+              </svg>
+              <svg v-else-if="item.icon === 'trending'" class="w-[18px] h-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941" />
+              </svg>
+              <svg v-else-if="item.icon === 'chart'" class="w-[18px] h-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+              </svg>
+              <span class="truncate">{{ item.label }}</span>
+            </NuxtLink>
+          </div>
+        </div>
+      </nav>
+    </aside>
+
+    <!-- Backdrop para móvil -->
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-150"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="sidebarOpen"
+        class="fixed inset-0 z-30 bg-black/60 lg:hidden"
+        @click="sidebarOpen = false"
+      />
+    </Transition>
+
+    <!-- ==================== CONTENIDO ==================== -->
+    <div class="lg:pl-64">
+      <!-- Topbar -->
+      <header class="sticky top-0 z-20 h-16 bg-gray-950/80 backdrop-blur-md border-b border-gray-800">
+        <div class="h-full px-4 sm:px-6 lg:px-8 flex items-center justify-between">
+          <!-- Botón menú móvil -->
+          <button
+            class="lg:hidden p-2 -ml-2 rounded-lg text-gray-400 hover:text-white hover:bg-gray-800 transition"
+            @click="sidebarOpen = true"
+          >
+            <svg class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+            </svg>
+          </button>
+
+          <div class="lg:hidden flex items-center gap-2">
+            <div class="w-8 h-8 bg-gradient-to-br from-emerald-400 to-emerald-600 rounded-lg flex items-center justify-center">
+              <svg class="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
-            <span class="text-lg font-bold text-white tracking-tight hidden sm:block">FODAF</span>
-          </NuxtLink>
-
-          <!-- Desktop Nav -->
-          <div class="hidden md:flex items-center gap-1">
-            <NuxtLink
-              v-for="item in visibleNavItems"
-              :key="item.to"
-              :to="item.to"
-              class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all"
-              :class="isActive(item.to)
-                ? 'bg-gray-800 text-white shadow-sm'
-                : 'text-gray-400 hover:text-white hover:bg-gray-800/50'"
-            >
-              <!-- Home -->
-              <svg v-if="item.icon === 'home'" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
-              </svg>
-              <!-- Banknotes -->
-              <svg v-else-if="item.icon === 'banknotes'" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />
-              </svg>
-              <!-- Shield -->
-              <svg v-else-if="item.icon === 'shield'" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
-              </svg>
-              <!-- Calendar -->
-              <svg v-else-if="item.icon === 'calendar'" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 9v9.75" />
-              </svg>
-              <!-- Users -->
-              <svg v-else-if="item.icon === 'users'" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
-              </svg>
-              <!-- Chart -->
-              <svg v-else-if="item.icon === 'chart'" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
-              </svg>
-              <span>{{ item.label }}</span>
-            </NuxtLink>
+            <span class="text-base font-bold text-white tracking-tight">FODAF</span>
           </div>
 
-          <!-- Right side: User dropdown -->
-          <div class="hidden md:block relative">
+          <div class="flex-1" />
+
+          <!-- User dropdown -->
+          <div class="relative">
             <button
-              class="flex items-center gap-2.5 px-3 py-1.5 rounded-lg hover:bg-gray-800 transition-all"
+              class="flex items-center gap-2.5 px-2 py-1.5 rounded-lg hover:bg-gray-800 transition-all"
               @click.stop="userMenuOpen = !userMenuOpen"
             >
               <div
-                class="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold"
+                class="w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold"
                 :class="profileRole === 'admin'
                   ? 'bg-emerald-500/20 text-emerald-400 ring-1 ring-emerald-500/30'
                   : 'bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30'"
               >
                 {{ initials }}
               </div>
+              <div class="hidden sm:flex flex-col items-start leading-tight">
+                <span class="text-sm font-medium text-white">{{ profileName }}</span>
+                <span class="text-[11px] text-gray-500">
+                  {{ profileRole === 'admin' ? 'Administrador' : 'Miembro' }}
+                </span>
+              </div>
               <svg
                 class="w-4 h-4 text-gray-500 transition-transform"
                 :class="{ 'rotate-180': userMenuOpen }"
-                fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
+                fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor"
               >
                 <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
               </svg>
             </button>
 
-            <!-- Dropdown -->
             <Transition
               enter-active-class="transition duration-150 ease-out"
               enter-from-class="opacity-0 scale-95 -translate-y-1"
@@ -166,10 +275,9 @@ async function handleLogout() {
             >
               <div
                 v-if="userMenuOpen"
-                class="absolute right-0 mt-2 w-56 rounded-xl bg-gray-800 border border-gray-700 shadow-xl shadow-black/20 overflow-hidden"
+                class="absolute right-0 mt-2 w-56 rounded-xl bg-gray-900 border border-gray-800 shadow-xl shadow-black/40 overflow-hidden"
               >
-                <!-- User info header -->
-                <div class="px-4 py-3 border-b border-gray-700">
+                <div class="px-4 py-3 border-b border-gray-800 sm:hidden">
                   <p class="text-sm font-medium text-white">{{ profileName }}</p>
                   <p class="text-xs text-gray-400">
                     {{ profileRole === 'admin' ? 'Administrador' : 'Miembro' }}
@@ -179,10 +287,10 @@ async function handleLogout() {
                 <div class="py-1">
                   <NuxtLink
                     to="/perfil"
-                    class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition"
+                    class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-300 hover:bg-gray-800 hover:text-white transition"
                     @click="userMenuOpen = false"
                   >
-                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
                     </svg>
                     Mi Perfil
@@ -192,7 +300,7 @@ async function handleLogout() {
                     class="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-red-400 hover:bg-red-500/10 transition"
                     @click="handleLogout"
                   >
-                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
                     </svg>
                     Cerrar Sesión
@@ -201,100 +309,13 @@ async function handleLogout() {
               </div>
             </Transition>
           </div>
-
-          <!-- Mobile menu button -->
-          <button
-            class="md:hidden p-2 rounded-lg text-gray-400 hover:text-white hover:bg-gray-800 transition"
-            @click="mobileMenuOpen = !mobileMenuOpen"
-          >
-            <svg v-if="!mobileMenuOpen" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-            </svg>
-            <svg v-else class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
-            </svg>
-          </button>
         </div>
-      </div>
+      </header>
 
-      <!-- Mobile menu -->
-      <Transition
-        enter-active-class="transition duration-200 ease-out"
-        enter-from-class="opacity-0 -translate-y-1"
-        enter-to-class="opacity-100 translate-y-0"
-        leave-active-class="transition duration-150 ease-in"
-        leave-from-class="opacity-100 translate-y-0"
-        leave-to-class="opacity-0 -translate-y-1"
-      >
-        <div v-if="mobileMenuOpen" class="md:hidden border-t border-gray-800 bg-gray-900/95 backdrop-blur-md">
-          <div class="px-4 py-3 space-y-1">
-            <NuxtLink
-              v-for="item in visibleNavItems"
-              :key="item.to"
-              :to="item.to"
-              class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all"
-              :class="isActive(item.to)
-                ? 'bg-gray-800 text-white'
-                : 'text-gray-400 hover:text-white hover:bg-gray-800/50'"
-              @click="mobileMenuOpen = false"
-            >
-              <svg v-if="item.icon === 'home'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
-              </svg>
-              <svg v-else-if="item.icon === 'banknotes'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />
-              </svg>
-              <svg v-else-if="item.icon === 'shield'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
-              </svg>
-              <svg v-else-if="item.icon === 'calendar'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 9v9.75" />
-              </svg>
-              <svg v-else-if="item.icon === 'users'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
-              </svg>
-              <svg v-else-if="item.icon === 'chart'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
-              </svg>
-              <span>{{ item.label }}</span>
-            </NuxtLink>
-          </div>
-
-          <!-- Mobile user section -->
-          <div class="px-4 py-3 border-t border-gray-800">
-            <div class="flex items-center gap-3 mb-3">
-              <div
-                class="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold"
-                :class="profileRole === 'admin'
-                  ? 'bg-emerald-500/20 text-emerald-400 ring-1 ring-emerald-500/30'
-                  : 'bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30'"
-              >
-                {{ initials }}
-              </div>
-              <div class="flex flex-col">
-                <span class="text-sm font-medium text-gray-200">{{ profileName }}</span>
-                <span class="text-xs text-gray-500">
-                  {{ profileRole === 'admin' ? 'Administrador' : 'Miembro' }}
-                </span>
-              </div>
-            </div>
-            <button
-              class="w-full flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg text-sm font-medium text-gray-400 hover:text-red-400 hover:bg-red-500/10 transition-all"
-              @click="handleLogout"
-            >
-              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
-              </svg>
-              <span>Cerrar Sesión</span>
-            </button>
-          </div>
-        </div>
-      </Transition>
-    </nav>
-
-    <!-- Content -->
-    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <slot />
-    </main>
+      <!-- Main -->
+      <main class="px-4 sm:px-6 lg:px-8 py-8 max-w-7xl mx-auto">
+        <slot />
+      </main>
+    </div>
   </div>
 </template>

--- a/app/pages/admin/actividades.vue
+++ b/app/pages/admin/actividades.vue
@@ -4,21 +4,31 @@ interface ProfileOption {
   full_name: string
 }
 
+interface TeamMemberRow {
+  role_title: string | null
+  profiles: {
+    id: string
+    full_name: string
+  }
+}
+
 interface TeamWithMembers {
   id: string
   name: string
   term: string
-  team_members: {
-    profiles: {
-      full_name: string
-    }
-  }[]
+  team_members: TeamMemberRow[]
+}
+
+interface SelectedMember {
+  profile_id: string
+  role_title: string
 }
 
 interface Activity {
   id: string
   name: string
   activity_date: string
+  team_id: string | null
   costs: number
   net_profits: number
   teams: {
@@ -42,7 +52,7 @@ const loading = ref(true)
 // Form comité
 const teamName = ref('')
 const teamTerm = ref('')
-const selectedMembers = ref<string[]>([])
+const selectedMembers = ref<SelectedMember[]>([])
 const creatingTeam = ref(false)
 
 // Form actividad
@@ -54,22 +64,37 @@ const activityCosts = ref<number | null>(null)
 const activityProfits = ref<number | null>(null)
 const creatingActivity = ref(false)
 
+// Edición
+interface EditingTeam {
+  id: string
+  name: string
+  term: string
+  members: SelectedMember[]
+}
+const editingTeam = ref<EditingTeam | null>(null)
+const editingActivity = ref<Activity | null>(null)
+const saving = ref(false)
+
+// Borrado
+const deleteTarget = ref<{ kind: 'team' | 'activity'; id: string; label: string } | null>(null)
+const deleting = ref(false)
+
 async function loadData() {
   const [membersResult, teamsResult, activitiesResult] = await Promise.all([
     supabase.from('profiles').select('id, full_name'),
     supabase
       .from('teams')
-      .select('id, name, term, team_members(profiles(full_name))')
+      .select('id, name, term, team_members(role_title, profiles(id, full_name))')
       .order('created_at', { ascending: false }),
     supabase
       .from('activities')
-      .select('id, name, activity_date, costs, net_profits, teams(name)')
+      .select('id, name, activity_date, team_id, costs, net_profits, teams(name)')
       .order('activity_date', { ascending: false }),
   ])
 
-  members.value = (membersResult.data as ProfileOption[]) ?? []
-  teams.value = (teamsResult.data as TeamWithMembers[]) ?? []
-  activities.value = (activitiesResult.data as Activity[]) ?? []
+  members.value = (membersResult.data as unknown as ProfileOption[]) ?? []
+  teams.value = (teamsResult.data as unknown as TeamWithMembers[]) ?? []
+  activities.value = (activitiesResult.data as unknown as Activity[]) ?? []
   loading.value = false
 }
 
@@ -91,9 +116,10 @@ async function createTeam() {
   }
 
   if (selectedMembers.value.length > 0) {
-    const rows = selectedMembers.value.map(profileId => ({
+    const rows = selectedMembers.value.map(m => ({
       team_id: newTeam.id,
-      profile_id: profileId,
+      profile_id: m.profile_id,
+      role_title: m.role_title.trim() || null,
     }))
 
     const { error: membersError } = await supabase.from('team_members').insert(rows)
@@ -144,9 +170,135 @@ async function createActivity() {
 }
 
 function toggleMember(id: string) {
-  const idx = selectedMembers.value.indexOf(id)
+  const idx = selectedMembers.value.findIndex(m => m.profile_id === id)
   if (idx >= 0) selectedMembers.value.splice(idx, 1)
-  else selectedMembers.value.push(id)
+  else selectedMembers.value.push({ profile_id: id, role_title: '' })
+}
+
+function isSelected(id: string): boolean {
+  return selectedMembers.value.some(m => m.profile_id === id)
+}
+
+function findMemberName(id: string): string {
+  return members.value.find(m => m.id === id)?.full_name ?? ''
+}
+
+function openEditTeam(team: TeamWithMembers) {
+  editingTeam.value = {
+    id: team.id,
+    name: team.name,
+    term: team.term,
+    members: team.team_members.map(tm => ({
+      profile_id: tm.profiles.id,
+      role_title: tm.role_title ?? '',
+    })),
+  }
+}
+
+function toggleEditMember(id: string) {
+  if (!editingTeam.value) return
+  const idx = editingTeam.value.members.findIndex(m => m.profile_id === id)
+  if (idx >= 0) editingTeam.value.members.splice(idx, 1)
+  else editingTeam.value.members.push({ profile_id: id, role_title: '' })
+}
+
+function isEditSelected(id: string): boolean {
+  return editingTeam.value?.members.some(m => m.profile_id === id) ?? false
+}
+
+async function saveTeamEdit() {
+  if (!editingTeam.value) return
+  saving.value = true
+  const t = editingTeam.value
+
+  const { error: updateError } = await supabase
+    .from('teams')
+    .update({ name: t.name, term: t.term })
+    .eq('id', t.id)
+
+  if (updateError) {
+    saving.value = false
+    toast.error('Error al actualizar el comité.')
+    return
+  }
+
+  // Re-sincronizar miembros: borrar todos los existentes y re-insertar los actuales.
+  const { error: delError } = await supabase.from('team_members').delete().eq('team_id', t.id)
+  if (delError) {
+    saving.value = false
+    toast.error('Error al sincronizar miembros.')
+    return
+  }
+
+  if (t.members.length > 0) {
+    const rows = t.members.map(m => ({
+      team_id: t.id,
+      profile_id: m.profile_id,
+      role_title: m.role_title.trim() || null,
+    }))
+    const { error: insError } = await supabase.from('team_members').insert(rows)
+    if (insError) {
+      saving.value = false
+      toast.error('Error al asignar miembros.')
+      return
+    }
+  }
+
+  saving.value = false
+  toast.success('Comité actualizado.')
+  editingTeam.value = null
+  await loadData()
+}
+
+function openEditActivity(a: Activity) {
+  editingActivity.value = { ...a }
+}
+
+async function saveActivityEdit() {
+  if (!editingActivity.value) return
+  saving.value = true
+  const a = editingActivity.value
+  const { error } = await supabase
+    .from('activities')
+    .update({
+      name: a.name,
+      activity_date: a.activity_date,
+      team_id: a.team_id || null,
+      costs: a.costs,
+      net_profits: a.net_profits,
+    })
+    .eq('id', a.id)
+  saving.value = false
+  if (error) {
+    toast.error('Error al guardar la actividad.')
+    return
+  }
+  toast.success('Actividad actualizada.')
+  editingActivity.value = null
+  await loadData()
+}
+
+function askDeleteTeam(team: TeamWithMembers) {
+  deleteTarget.value = { kind: 'team', id: team.id, label: `el comité "${team.name}"` }
+}
+
+function askDeleteActivity(a: Activity) {
+  deleteTarget.value = { kind: 'activity', id: a.id, label: `la actividad "${a.name}"` }
+}
+
+async function confirmDelete() {
+  if (!deleteTarget.value) return
+  deleting.value = true
+  const table = deleteTarget.value.kind === 'team' ? 'teams' : 'activities'
+  const { error } = await supabase.from(table).delete().eq('id', deleteTarget.value.id)
+  deleting.value = false
+  if (error) {
+    toast.error(`No se pudo eliminar: ${error.message}`)
+    return
+  }
+  toast.success('Registro eliminado.')
+  deleteTarget.value = null
+  await loadData()
 }
 
 function formatCOP(value: number): string {
@@ -223,19 +375,37 @@ onMounted(loadData)
             <!-- Selector de miembros -->
             <div>
               <p class="text-sm font-medium text-gray-300 mb-2">Integrantes</p>
-              <div class="flex flex-wrap gap-2">
+              <div class="flex flex-wrap gap-2 mb-3">
                 <button
                   v-for="member in members"
                   :key="member.id"
                   type="button"
                   class="px-3 py-1.5 text-xs font-medium rounded-lg border transition"
-                  :class="selectedMembers.includes(member.id)
+                  :class="isSelected(member.id)
                     ? 'border-emerald-500 bg-emerald-500/20 text-emerald-400'
                     : 'border-gray-700 bg-gray-800 text-gray-400 hover:border-gray-600'"
                   @click="toggleMember(member.id)"
                 >
                   {{ member.full_name }}
                 </button>
+              </div>
+
+              <!-- Cargos de los seleccionados -->
+              <div v-if="selectedMembers.length > 0" class="space-y-2 pt-3 border-t border-gray-800">
+                <p class="text-xs font-medium text-gray-400 uppercase tracking-wider mb-2">Cargos</p>
+                <div
+                  v-for="selected in selectedMembers"
+                  :key="selected.profile_id"
+                  class="flex items-center gap-3"
+                >
+                  <span class="text-sm text-gray-300 flex-1 truncate">{{ findMemberName(selected.profile_id) }}</span>
+                  <input
+                    v-model="selected.role_title"
+                    type="text"
+                    placeholder="Cargo (ej. Tesorero)"
+                    class="w-56 rounded-lg border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+                  />
+                </div>
               </div>
             </div>
 
@@ -261,9 +431,29 @@ onMounted(loadData)
           >
             <div class="flex items-center justify-between mb-3">
               <h3 class="text-base font-semibold text-white">{{ team.name }}</h3>
-              <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-blue-500/20 text-blue-400">
-                {{ team.term }}
-              </span>
+              <div class="flex items-center gap-2">
+                <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-blue-500/20 text-blue-400">
+                  {{ team.term }}
+                </span>
+                <button
+                  class="rounded-md bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                  title="Editar"
+                  @click="openEditTeam(team)"
+                >
+                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                  </svg>
+                </button>
+                <button
+                  class="rounded-md bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
+                  title="Eliminar"
+                  @click="askDeleteTeam(team)"
+                >
+                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                  </svg>
+                </button>
+              </div>
             </div>
             <div v-if="team.team_members.length > 0" class="flex flex-wrap gap-1.5">
               <span
@@ -271,7 +461,7 @@ onMounted(loadData)
                 :key="i"
                 class="px-2.5 py-1 text-xs rounded-full bg-gray-800 text-gray-300"
               >
-                {{ tm.profiles.full_name }}
+                {{ tm.profiles.full_name }}<span v-if="tm.role_title" class="text-emerald-400"> · {{ tm.role_title }}</span>
               </span>
             </div>
             <p v-else class="text-xs text-gray-500">Sin integrantes asignados.</p>
@@ -378,6 +568,7 @@ onMounted(loadData)
                 <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Comité</th>
                 <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Costos</th>
                 <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Ganancia Neta</th>
+                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Acciones</th>
               </tr>
             </thead>
             <tbody>
@@ -401,11 +592,219 @@ onMounted(loadData)
                 <td class="px-6 py-4 text-right">
                   <span class="text-sm font-semibold text-emerald-400">{{ formatCOP(activity.net_profits) }}</span>
                 </td>
+                <td class="px-6 py-4">
+                  <div class="flex items-center justify-end gap-2">
+                    <button
+                      class="rounded-md bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                      title="Editar"
+                      @click="openEditActivity(activity)"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                      </svg>
+                    </button>
+                    <button
+                      class="rounded-md bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
+                      title="Eliminar"
+                      @click="askDeleteActivity(activity)"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
               </tr>
             </tbody>
           </table>
         </div>
       </div>
     </template>
+
+    <!-- Modal editar comité -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="editingTeam" class="fixed inset-0 z-50 flex items-center justify-center px-4 overflow-y-auto py-8">
+          <div class="absolute inset-0 bg-black/60" @click="editingTeam = null" />
+          <div class="relative w-full max-w-lg bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Editar Comité</h2>
+            <form class="space-y-4" @submit.prevent="saveTeamEdit">
+              <div class="flex gap-3">
+                <div class="flex-1">
+                  <label class="block text-sm font-medium text-gray-300 mb-1">Nombre</label>
+                  <input
+                    v-model="editingTeam.name"
+                    type="text"
+                    required
+                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                  />
+                </div>
+                <div class="w-32">
+                  <label class="block text-sm font-medium text-gray-300 mb-1">Período</label>
+                  <input
+                    v-model="editingTeam.term"
+                    type="text"
+                    required
+                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                  />
+                </div>
+              </div>
+              <div>
+                <p class="text-sm font-medium text-gray-300 mb-2">Integrantes</p>
+                <div class="flex flex-wrap gap-2 mb-3">
+                  <button
+                    v-for="member in members"
+                    :key="member.id"
+                    type="button"
+                    class="px-3 py-1.5 text-xs font-medium rounded-lg border transition"
+                    :class="isEditSelected(member.id)
+                      ? 'border-emerald-500 bg-emerald-500/20 text-emerald-400'
+                      : 'border-gray-700 bg-gray-800 text-gray-400 hover:border-gray-600'"
+                    @click="toggleEditMember(member.id)"
+                  >
+                    {{ member.full_name }}
+                  </button>
+                </div>
+                <div v-if="editingTeam.members.length > 0" class="space-y-2 pt-3 border-t border-gray-800">
+                  <p class="text-xs font-medium text-gray-400 uppercase tracking-wider mb-2">Cargos</p>
+                  <div
+                    v-for="selected in editingTeam.members"
+                    :key="selected.profile_id"
+                    class="flex items-center gap-3"
+                  >
+                    <span class="text-sm text-gray-300 flex-1 truncate">{{ findMemberName(selected.profile_id) }}</span>
+                    <input
+                      v-model="selected.role_title"
+                      type="text"
+                      placeholder="Cargo"
+                      class="w-56 rounded-lg border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="editingTeam = null"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="saving"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ saving ? 'Guardando...' : 'Guardar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <!-- Modal editar actividad -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="editingActivity" class="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div class="absolute inset-0 bg-black/60" @click="editingActivity = null" />
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Editar Actividad</h2>
+            <form class="space-y-4" @submit.prevent="saveActivityEdit">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Nombre</label>
+                <input
+                  v-model="editingActivity.name"
+                  type="text"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Fecha</label>
+                <input
+                  v-model="editingActivity.activity_date"
+                  type="date"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Comité</label>
+                <select
+                  v-model="editingActivity.team_id"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option :value="null">Sin comité</option>
+                  <option v-for="team in teams" :key="team.id" :value="team.id">
+                    {{ team.name }} ({{ team.term }})
+                  </option>
+                </select>
+              </div>
+              <div class="grid grid-cols-2 gap-3">
+                <div>
+                  <label class="block text-sm font-medium text-gray-300 mb-1">Costos (COP)</label>
+                  <input
+                    v-model.number="editingActivity.costs"
+                    type="number"
+                    min="0"
+                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                  />
+                </div>
+                <div>
+                  <label class="block text-sm font-medium text-gray-300 mb-1">Ganancia (COP)</label>
+                  <input
+                    v-model.number="editingActivity.net_profits"
+                    type="number"
+                    min="0"
+                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                  />
+                </div>
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="editingActivity = null"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="saving"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ saving ? 'Guardando...' : 'Guardar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <ConfirmModal
+      :visible="deleteTarget !== null"
+      title="Eliminar registro"
+      :message="`¿Seguro que quieres eliminar ${deleteTarget?.label ?? ''}? Esta acción no se puede deshacer.`"
+      :loading="deleting"
+      @cancel="deleteTarget = null"
+      @confirm="confirmDelete"
+    />
   </div>
 </template>

--- a/app/pages/admin/balance.vue
+++ b/app/pages/admin/balance.vue
@@ -6,15 +6,18 @@ definePageMeta({
 
 const supabase = useSupabase()
 
-const totalSavings = ref(0)
+const totalContributions = ref(0)
 const totalActiveLoans = ref(0)
 const totalActivityProfits = ref(0)
 const totalPenaltiesCollected = ref(0)
+const totalWithdrawals = ref(0)
+const totalInvested = ref(0)
+const totalInvestmentReturns = ref(0)
 const totalMembers = ref(0)
 const loading = ref(true)
 
 onMounted(async () => {
-  const [savingsResult, loansResult, activitiesResult, penaltiesResult, membersResult] = await Promise.all([
+  const [savingsResult, loansResult, activitiesResult, penaltiesResult, withdrawalsResult, investmentsResult, completedInvestmentsResult, membersResult] = await Promise.all([
     supabase
       .from('contributions')
       .select('amount')
@@ -31,11 +34,23 @@ onMounted(async () => {
       .select('amount, status')
       .in('status', ['paid', 'deducted_from_savings']),
     supabase
+      .from('withdrawals')
+      .select('amount')
+      .eq('status', 'approved'),
+    supabase
+      .from('investments')
+      .select('invested_amount')
+      .eq('status', 'active'),
+    supabase
+      .from('investments')
+      .select('actual_return')
+      .eq('status', 'completed'),
+    supabase
       .from('profiles')
       .select('id', { count: 'exact', head: true }),
   ])
 
-  totalSavings.value = savingsResult.data
+  totalContributions.value = savingsResult.data
     ? savingsResult.data.reduce((sum, c) => sum + c.amount, 0)
     : 0
 
@@ -51,13 +66,34 @@ onMounted(async () => {
     ? penaltiesResult.data.reduce((sum, p) => sum + p.amount, 0)
     : 0
 
+  totalWithdrawals.value = withdrawalsResult.data
+    ? withdrawalsResult.data.reduce((sum, w) => sum + w.amount, 0)
+    : 0
+
+  totalInvested.value = investmentsResult.data
+    ? investmentsResult.data.reduce((sum, i) => sum + i.invested_amount, 0)
+    : 0
+
+  totalInvestmentReturns.value = completedInvestmentsResult.data
+    ? completedInvestmentsResult.data.reduce((sum, i) => sum + (i.actual_return ?? 0), 0)
+    : 0
+
   totalMembers.value = membersResult.count ?? 0
 
   loading.value = false
 })
 
+const totalSavings = computed(() =>
+  Math.max(0, totalContributions.value - totalWithdrawals.value),
+)
+
 const capitalInHand = computed(() =>
-  totalSavings.value + totalActivityProfits.value + totalPenaltiesCollected.value - totalActiveLoans.value,
+  totalSavings.value
+  + totalActivityProfits.value
+  + totalPenaltiesCollected.value
+  + totalInvestmentReturns.value
+  - totalActiveLoans.value
+  - totalInvested.value,
 )
 
 function formatCOP(value: number): string {
@@ -91,9 +127,9 @@ function formatCOP(value: number): string {
       <div class="bg-gradient-to-br from-violet-600/20 to-blue-600/20 rounded-2xl border border-violet-500/30 p-8 mb-6">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-violet-300 uppercase tracking-wider">Capital Actual en Caja</p>
+            <p class="text-sm font-medium text-violet-300 uppercase tracking-wider">Capital Actual en Caja (Disponible)</p>
             <p class="text-5xl font-bold text-white mt-3">{{ formatCOP(capitalInHand) }}</p>
-            <p class="text-sm text-violet-300/70 mt-2">Ahorros + Ganancias + Multas − Préstamos activos</p>
+            <p class="text-sm text-violet-300/70 mt-2">Ahorros + Ganancias actividades + Ganancias CDT + Multas − Préstamos − Inversiones activas</p>
           </div>
           <div class="hidden sm:block">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-20 w-20 text-violet-500/30" viewBox="0 0 20 20" fill="currentColor">
@@ -117,7 +153,10 @@ function formatCOP(value: number): string {
             <p class="text-sm font-medium text-gray-400">Total Ahorrado</p>
           </div>
           <p class="text-2xl font-bold text-emerald-400">{{ formatCOP(totalSavings) }}</p>
-          <p class="text-xs text-gray-500 mt-1">Aportes aprobados de todos los miembros</p>
+          <p class="text-xs text-gray-500 mt-1">
+            Aportes aprobados menos retiros
+            <span v-if="totalWithdrawals > 0">(−{{ formatCOP(totalWithdrawals) }})</span>
+          </p>
         </div>
 
         <!-- Ganancias Actividades -->
@@ -160,6 +199,34 @@ function formatCOP(value: number): string {
           </div>
           <p class="text-2xl font-bold text-orange-400">{{ formatCOP(totalActiveLoans) }}</p>
           <p class="text-xs text-gray-500 mt-1">Capital prestado pendiente de cobro</p>
+        </div>
+
+        <!-- Dinero en Inversiones -->
+        <div class="bg-gray-900 rounded-2xl border border-gray-800 p-6">
+          <div class="flex items-center gap-3 mb-3">
+            <div class="h-10 w-10 rounded-xl bg-blue-500/10 flex items-center justify-center">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />
+              </svg>
+            </div>
+            <p class="text-sm font-medium text-gray-400">Dinero en Inversiones (CDT)</p>
+          </div>
+          <p class="text-2xl font-bold text-blue-400">{{ formatCOP(totalInvested) }}</p>
+          <p class="text-xs text-gray-500 mt-1">Capital en inversiones externas activas</p>
+        </div>
+
+        <!-- Ganancias por Inversiones (CDT) -->
+        <div class="bg-gray-900 rounded-2xl border border-gray-800 p-6">
+          <div class="flex items-center gap-3 mb-3">
+            <div class="h-10 w-10 rounded-xl bg-cyan-500/10 flex items-center justify-center">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-cyan-400" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676.662C6.602 7.234 6 8.005 6 9c0 .995.602 1.766 1.324 2.246.48.32 1.054.545 1.676.662v1.941c-.391-.127-.68-.317-.843-.504a1 1 0 10-1.51 1.31c.562.649 1.413 1.076 2.353 1.253V17a1 1 0 102 0v-.092a4.535 4.535 0 001.676-.662C13.398 15.766 14 14.995 14 14c0-.995-.602-1.766-1.324-2.246A4.535 4.535 0 0011 11.092V9.151c.391.127.68.317.843.504a1 1 0 101.511-1.31c-.563-.649-1.413-1.076-2.354-1.253V6z" clip-rule="evenodd" />
+              </svg>
+            </div>
+            <p class="text-sm font-medium text-gray-400">Ganancias por Inversiones (CDT)</p>
+          </div>
+          <p class="text-2xl font-bold text-cyan-400">{{ formatCOP(totalInvestmentReturns) }}</p>
+          <p class="text-xs text-gray-500 mt-1">Rendimientos reales recibidos al finalizar CDT</p>
         </div>
       </div>
 

--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -1,27 +1,30 @@
 <script setup lang="ts">
-interface PendingContribution {
+interface ProfileOption {
   id: string
-  amount: number
-  deposit_date: string
-  created_at: string
-  profiles: {
-    full_name: string
-  }
+  full_name: string
 }
 
-interface PendingLoan {
+interface AdminContribution {
   id: string
+  profile_id: string
+  amount: number
+  deposit_date: string
+  status: 'pending' | 'approved' | 'rejected'
+  created_at: string
+  profiles: { full_name: string }
+}
+
+interface AdminLoan {
+  id: string
+  profile_id: string
+  guarantor_id: string | null
   requested_amount: number
   interest_rate: number
   installments: number
-  guarantor_id: string | null
+  status: 'pending' | 'active' | 'paid' | 'defaulted' | 'rejected'
   created_at: string
-  profiles: {
-    full_name: string
-  }
-  guarantor: {
-    full_name: string
-  } | null
+  profiles: { full_name: string }
+  guarantor: { full_name: string } | null
 }
 
 definePageMeta({
@@ -33,68 +36,255 @@ const supabase = useSupabase()
 const toast = useToast()
 
 const activeTab = ref<'contributions' | 'loans'>('contributions')
-const contributions = ref<PendingContribution[]>([])
-const loans = ref<PendingLoan[]>([])
+const contributions = ref<AdminContribution[]>([])
+const loans = ref<AdminLoan[]>([])
+const profiles = ref<ProfileOption[]>([])
 const loading = ref(true)
 const processingId = ref<string | null>(null)
 
-async function loadPending() {
-  const [contribResult, loansResult] = await Promise.all([
+const contribFilter = ref<'all' | 'pending' | 'approved' | 'rejected'>('pending')
+const loanFilter = ref<'all' | 'pending' | 'active' | 'paid' | 'defaulted' | 'rejected'>('pending')
+
+// Modales de edición
+const editingContribution = ref<AdminContribution | null>(null)
+const editingLoan = ref<AdminLoan | null>(null)
+const saving = ref(false)
+
+// Modal de confirmación de borrado
+const deleteTarget = ref<{ kind: 'contribution' | 'loan' | 'payment'; id: string; label: string } | null>(null)
+const deleting = ref(false)
+
+// Gestión de pagos
+interface LoanPayment {
+  id: string
+  loan_id: string
+  amount: number
+  payment_date: string
+}
+const paymentsLoan = ref<AdminLoan | null>(null)
+const paymentsList = ref<LoanPayment[]>([])
+const paymentsLoading = ref(false)
+const editingPayment = ref<LoanPayment | null>(null)
+
+async function loadData() {
+  loading.value = true
+  const [contribResult, loansResult, profilesResult] = await Promise.all([
     supabase
       .from('contributions')
-      .select('id, amount, deposit_date, created_at, profiles(full_name)')
-      .eq('status', 'pending')
-      .order('created_at', { ascending: true }),
+      .select('id, profile_id, amount, deposit_date, status, created_at, profiles(full_name)')
+      .order('created_at', { ascending: false }),
     supabase
       .from('loans')
-      .select('id, requested_amount, interest_rate, installments, guarantor_id, created_at, profiles!loans_profile_id_fkey(full_name), guarantor:profiles!loans_guarantor_id_fkey(full_name)')
-      .eq('status', 'pending')
-      .order('created_at', { ascending: true }),
+      .select('id, profile_id, guarantor_id, requested_amount, interest_rate, installments, status, created_at, profiles!loans_profile_id_fkey(full_name), guarantor:profiles!loans_guarantor_id_fkey(full_name)')
+      .order('created_at', { ascending: false }),
+    supabase.from('profiles').select('id, full_name').order('full_name'),
   ])
 
-  contributions.value = (contribResult.data as PendingContribution[]) ?? []
-  loans.value = (loansResult.data as PendingLoan[]) ?? []
+  contributions.value = (contribResult.data as unknown as AdminContribution[]) ?? []
+  loans.value = (loansResult.data as unknown as AdminLoan[]) ?? []
+  profiles.value = (profilesResult.data as unknown as ProfileOption[]) ?? []
   loading.value = false
 }
 
-async function updateContribution(id: string, status: 'approved' | 'rejected') {
-  processingId.value = id
+const filteredContributions = computed(() =>
+  contribFilter.value === 'all'
+    ? contributions.value
+    : contributions.value.filter(c => c.status === contribFilter.value),
+)
 
-  const { error } = await supabase
-    .from('contributions')
-    .update({ status })
-    .eq('id', id)
+const filteredLoans = computed(() =>
+  loanFilter.value === 'all'
+    ? loans.value
+    : loans.value.filter(l => l.status === loanFilter.value),
+)
+
+async function setContributionStatus(id: string, status: 'approved' | 'rejected') {
+  processingId.value = id
+  const { error } = await supabase.from('contributions').update({ status }).eq('id', id)
+  processingId.value = null
 
   if (error) {
     toast.error('Error al actualizar el aporte.')
-    processingId.value = null
     return
   }
 
-  contributions.value = contributions.value.filter(c => c.id !== id)
-  processingId.value = null
   toast.success(status === 'approved' ? 'Aporte aprobado.' : 'Aporte rechazado.')
+  await loadData()
 }
 
-async function updateLoan(id: string, status: 'active' | 'rejected') {
+async function setLoanStatus(id: string, status: 'active' | 'rejected') {
   processingId.value = id
-
-  const { error } = await supabase
-    .from('loans')
-    .update({ status })
-    .eq('id', id)
+  const { error } = await supabase.from('loans').update({ status }).eq('id', id)
+  processingId.value = null
 
   if (error) {
     toast.error('Error al actualizar el préstamo.')
-    processingId.value = null
     return
   }
 
-  loans.value = loans.value.filter(l => l.id !== id)
-  processingId.value = null
   toast.success(status === 'active' ? 'Préstamo aprobado.' : 'Préstamo rechazado.')
+  await loadData()
 }
 
+// ---------- Edición de aportes ----------
+function openEditContribution(c: AdminContribution) {
+  editingContribution.value = { ...c }
+}
+
+function closeEditContribution() {
+  editingContribution.value = null
+}
+
+async function saveContribution() {
+  if (!editingContribution.value) return
+  saving.value = true
+  const c = editingContribution.value
+  const { error } = await supabase
+    .from('contributions')
+    .update({
+      profile_id: c.profile_id,
+      amount: c.amount,
+      deposit_date: c.deposit_date,
+      status: c.status,
+    })
+    .eq('id', c.id)
+  saving.value = false
+
+  if (error) {
+    toast.error('Error al guardar el aporte.')
+    return
+  }
+
+  toast.success('Aporte actualizado.')
+  closeEditContribution()
+  await loadData()
+}
+
+// ---------- Edición de préstamos ----------
+function openEditLoan(l: AdminLoan) {
+  editingLoan.value = { ...l }
+}
+
+function closeEditLoan() {
+  editingLoan.value = null
+}
+
+async function saveLoan() {
+  if (!editingLoan.value) return
+  saving.value = true
+  const l = editingLoan.value
+  const { error } = await supabase
+    .from('loans')
+    .update({
+      profile_id: l.profile_id,
+      guarantor_id: l.guarantor_id || null,
+      requested_amount: l.requested_amount,
+      interest_rate: l.interest_rate,
+      installments: l.installments,
+      status: l.status,
+    })
+    .eq('id', l.id)
+  saving.value = false
+
+  if (error) {
+    toast.error('Error al guardar el préstamo.')
+    return
+  }
+
+  toast.success('Préstamo actualizado.')
+  closeEditLoan()
+  await loadData()
+}
+
+// ---------- Pagos de préstamo ----------
+async function openPayments(loan: AdminLoan) {
+  paymentsLoan.value = loan
+  paymentsLoading.value = true
+  const { data } = await supabase
+    .from('loan_payments')
+    .select('id, loan_id, amount, payment_date')
+    .eq('loan_id', loan.id)
+    .order('payment_date', { ascending: false })
+  paymentsList.value = (data as LoanPayment[]) ?? []
+  paymentsLoading.value = false
+}
+
+function closePayments() {
+  paymentsLoan.value = null
+  paymentsList.value = []
+  editingPayment.value = null
+}
+
+function startEditPayment(p: LoanPayment) {
+  editingPayment.value = { ...p }
+}
+
+async function savePayment() {
+  if (!editingPayment.value) return
+  saving.value = true
+  const p = editingPayment.value
+  const { error } = await supabase
+    .from('loan_payments')
+    .update({ amount: p.amount, payment_date: p.payment_date })
+    .eq('id', p.id)
+  saving.value = false
+  if (error) {
+    toast.error('Error al guardar el pago.')
+    return
+  }
+  toast.success('Pago actualizado.')
+  editingPayment.value = null
+  if (paymentsLoan.value) await openPayments(paymentsLoan.value)
+}
+
+function askDeletePayment(p: LoanPayment) {
+  deleteTarget.value = {
+    kind: 'payment',
+    id: p.id,
+    label: `el pago de ${formatCOP(p.amount)} del ${formatDate(p.payment_date)}`,
+  }
+}
+
+// ---------- Eliminación ----------
+function askDeleteContribution(c: AdminContribution) {
+  deleteTarget.value = {
+    kind: 'contribution',
+    id: c.id,
+    label: `el aporte de ${c.profiles.full_name} (${formatCOP(c.amount)})`,
+  }
+}
+
+function askDeleteLoan(l: AdminLoan) {
+  deleteTarget.value = {
+    kind: 'loan',
+    id: l.id,
+    label: `el préstamo de ${l.profiles.full_name} (${formatCOP(l.requested_amount)})`,
+  }
+}
+
+async function confirmDelete() {
+  if (!deleteTarget.value) return
+  deleting.value = true
+  const kind = deleteTarget.value.kind
+  const table = kind === 'contribution' ? 'contributions' : kind === 'loan' ? 'loans' : 'loan_payments'
+  const { error } = await supabase.from(table).delete().eq('id', deleteTarget.value.id)
+  deleting.value = false
+
+  if (error) {
+    toast.error(`No se pudo eliminar: ${error.message}`)
+    return
+  }
+
+  toast.success('Registro eliminado.')
+  deleteTarget.value = null
+  if (kind === 'payment' && paymentsLoan.value) {
+    await openPayments(paymentsLoan.value)
+  } else {
+    await loadData()
+  }
+}
+
+// ---------- Helpers ----------
 function formatCOP(value: number): string {
   return new Intl.NumberFormat('es-CO', {
     style: 'currency',
@@ -104,17 +294,45 @@ function formatCOP(value: number): string {
 }
 
 function formatDate(dateStr: string): string {
-  return new Date(dateStr + 'T12:00:00').toLocaleDateString('es-CO', {
+  return new Date(dateStr.slice(0, 10) + 'T12:00:00').toLocaleDateString('es-CO', {
     day: 'numeric',
     month: 'short',
     year: 'numeric',
   })
 }
 
-const pendingContributionsCount = computed(() => contributions.value.length)
-const pendingLoansCount = computed(() => loans.value.length)
+const contribStatusLabels: Record<string, string> = {
+  pending: 'Pendiente',
+  approved: 'Aprobado',
+  rejected: 'Rechazado',
+}
 
-onMounted(loadPending)
+const contribStatusClasses: Record<string, string> = {
+  pending: 'bg-yellow-500/20 text-yellow-400',
+  approved: 'bg-emerald-500/20 text-emerald-400',
+  rejected: 'bg-red-500/20 text-red-400',
+}
+
+const loanStatusLabels: Record<string, string> = {
+  pending: 'Pendiente',
+  active: 'Activo',
+  paid: 'Pagado',
+  defaulted: 'En mora',
+  rejected: 'Rechazado',
+}
+
+const loanStatusClasses: Record<string, string> = {
+  pending: 'bg-yellow-500/20 text-yellow-400',
+  active: 'bg-emerald-500/20 text-emerald-400',
+  paid: 'bg-gray-500/20 text-gray-400',
+  defaulted: 'bg-red-500/20 text-red-400',
+  rejected: 'bg-red-500/20 text-red-400',
+}
+
+const pendingContributionsCount = computed(() => contributions.value.filter(c => c.status === 'pending').length)
+const pendingLoansCount = computed(() => loans.value.filter(l => l.status === 'pending').length)
+
+onMounted(loadData)
 </script>
 
 <template>
@@ -122,16 +340,14 @@ onMounted(loadPending)
     <!-- Header -->
     <div class="mb-8">
       <h1 class="text-2xl font-bold text-white">Panel de Administración</h1>
-      <p class="text-gray-400 mt-1">Gestión de aportes y préstamos pendientes.</p>
+      <p class="text-gray-400 mt-1">Gestión completa de aportes y préstamos.</p>
     </div>
 
     <!-- Tabs -->
     <div class="flex gap-1 mb-6 bg-gray-900 rounded-xl p-1 border border-gray-800 w-fit">
       <button
         class="px-5 py-2 text-sm font-medium rounded-lg transition"
-        :class="activeTab === 'contributions'
-          ? 'bg-gray-800 text-white'
-          : 'text-gray-400 hover:text-white'"
+        :class="activeTab === 'contributions' ? 'bg-gray-800 text-white' : 'text-gray-400 hover:text-white'"
         @click="activeTab = 'contributions'"
       >
         Aportes
@@ -144,9 +360,7 @@ onMounted(loadPending)
       </button>
       <button
         class="px-5 py-2 text-sm font-medium rounded-lg transition"
-        :class="activeTab === 'loans'
-          ? 'bg-gray-800 text-white'
-          : 'text-gray-400 hover:text-white'"
+        :class="activeTab === 'loans' ? 'bg-gray-800 text-white' : 'text-gray-400 hover:text-white'"
         @click="activeTab = 'loans'"
       >
         Préstamos
@@ -161,37 +375,47 @@ onMounted(loadPending)
 
     <!-- Skeleton -->
     <div v-if="loading" class="space-y-3">
-      <div
-        v-for="i in 3"
-        :key="i"
-        class="animate-pulse bg-gray-900 rounded-xl h-20 border border-gray-800"
-      />
+      <div v-for="i in 3" :key="i" class="animate-pulse bg-gray-900 rounded-xl h-20 border border-gray-800" />
     </div>
 
     <!-- ==================== APORTES ==================== -->
     <template v-else-if="activeTab === 'contributions'">
-      <!-- Empty -->
-      <div
-        v-if="contributions.length === 0"
-        class="bg-gray-900 rounded-2xl border border-gray-800 p-12 text-center"
-      >
-        <p class="text-gray-400 text-lg">No hay aportes pendientes de revisión.</p>
+      <!-- Filtros -->
+      <div class="flex gap-2 mb-4">
+        <button
+          v-for="f in (['pending', 'approved', 'rejected', 'all'] as const)"
+          :key="f"
+          class="px-3 py-1.5 text-xs font-medium rounded-lg border transition"
+          :class="contribFilter === f
+            ? 'border-emerald-500 bg-emerald-500/20 text-emerald-400'
+            : 'border-gray-700 bg-gray-800 text-gray-400 hover:border-gray-600'"
+          @click="contribFilter = f"
+        >
+          {{ f === 'all' ? 'Todos' : contribStatusLabels[f] }}
+        </button>
       </div>
 
-      <!-- Table -->
+      <div
+        v-if="filteredContributions.length === 0"
+        class="bg-gray-900 rounded-2xl border border-gray-800 p-12 text-center"
+      >
+        <p class="text-gray-400 text-lg">No hay aportes para mostrar.</p>
+      </div>
+
       <div v-else class="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
         <table class="w-full">
           <thead>
             <tr class="border-b border-gray-800">
               <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Miembro</th>
-              <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Fecha de Depósito</th>
+              <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Fecha</th>
               <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Monto</th>
+              <th class="text-center text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Estado</th>
               <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Acciones</th>
             </tr>
           </thead>
           <tbody>
             <tr
-              v-for="c in contributions"
+              v-for="c in filteredContributions"
               :key="c.id"
               class="border-b border-gray-800/50 last:border-0 hover:bg-gray-800/30 transition"
             >
@@ -204,21 +428,46 @@ onMounted(loadPending)
               <td class="px-6 py-4 text-right">
                 <span class="text-sm font-semibold text-white">{{ formatCOP(c.amount) }}</span>
               </td>
+              <td class="px-6 py-4 text-center">
+                <span class="px-2 py-0.5 text-xs font-medium rounded-full" :class="contribStatusClasses[c.status]">
+                  {{ contribStatusLabels[c.status] }}
+                </span>
+              </td>
               <td class="px-6 py-4">
                 <div class="flex items-center justify-end gap-2">
+                  <template v-if="c.status === 'pending'">
+                    <button
+                      :disabled="processingId === c.id"
+                      class="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                      @click="setContributionStatus(c.id, 'approved')"
+                    >
+                      Aprobar
+                    </button>
+                    <button
+                      :disabled="processingId === c.id"
+                      class="rounded-lg bg-red-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-red-500 transition disabled:opacity-50"
+                      @click="setContributionStatus(c.id, 'rejected')"
+                    >
+                      Rechazar
+                    </button>
+                  </template>
                   <button
-                    :disabled="processingId === c.id"
-                    class="rounded-lg bg-emerald-600 px-4 py-1.5 text-xs font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
-                    @click="updateContribution(c.id, 'approved')"
+                    class="rounded-lg bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                    title="Editar"
+                    @click="openEditContribution(c)"
                   >
-                    Aprobar
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                    </svg>
                   </button>
                   <button
-                    :disabled="processingId === c.id"
-                    class="rounded-lg bg-red-600 px-4 py-1.5 text-xs font-semibold text-white hover:bg-red-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
-                    @click="updateContribution(c.id, 'rejected')"
+                    class="rounded-lg bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
+                    title="Eliminar"
+                    @click="askDeleteContribution(c)"
                   >
-                    Rechazar
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
                   </button>
                 </div>
               </td>
@@ -230,25 +479,43 @@ onMounted(loadPending)
 
     <!-- ==================== PRÉSTAMOS ==================== -->
     <template v-else-if="activeTab === 'loans'">
-      <!-- Empty -->
-      <div
-        v-if="loans.length === 0"
-        class="bg-gray-900 rounded-2xl border border-gray-800 p-12 text-center"
-      >
-        <p class="text-gray-400 text-lg">No hay solicitudes de préstamos pendientes.</p>
+      <!-- Filtros -->
+      <div class="flex flex-wrap gap-2 mb-4">
+        <button
+          v-for="f in (['pending', 'active', 'paid', 'defaulted', 'rejected', 'all'] as const)"
+          :key="f"
+          class="px-3 py-1.5 text-xs font-medium rounded-lg border transition"
+          :class="loanFilter === f
+            ? 'border-emerald-500 bg-emerald-500/20 text-emerald-400'
+            : 'border-gray-700 bg-gray-800 text-gray-400 hover:border-gray-600'"
+          @click="loanFilter = f"
+        >
+          {{ f === 'all' ? 'Todos' : loanStatusLabels[f] }}
+        </button>
       </div>
 
-      <!-- Cards -->
+      <div
+        v-if="filteredLoans.length === 0"
+        class="bg-gray-900 rounded-2xl border border-gray-800 p-12 text-center"
+      >
+        <p class="text-gray-400 text-lg">No hay préstamos para mostrar.</p>
+      </div>
+
       <div v-else class="space-y-4">
         <div
-          v-for="loan in loans"
+          v-for="loan in filteredLoans"
           :key="loan.id"
           class="bg-gray-900 rounded-2xl border border-gray-800 p-6"
         >
           <div class="flex items-start justify-between mb-4">
             <div>
-              <p class="text-lg font-semibold text-white">{{ loan.profiles.full_name }}</p>
-              <p class="text-xs text-gray-500 mt-0.5">Solicitado el {{ formatDate(loan.created_at.slice(0, 10)) }}</p>
+              <div class="flex items-center gap-2">
+                <p class="text-lg font-semibold text-white">{{ loan.profiles.full_name }}</p>
+                <span class="px-2 py-0.5 text-xs font-medium rounded-full" :class="loanStatusClasses[loan.status]">
+                  {{ loanStatusLabels[loan.status] }}
+                </span>
+              </div>
+              <p class="text-xs text-gray-500 mt-0.5">Solicitado el {{ formatDate(loan.created_at) }}</p>
             </div>
             <p class="text-2xl font-bold text-white">{{ formatCOP(loan.requested_amount) }}</p>
           </div>
@@ -271,23 +538,339 @@ onMounted(loadPending)
           </div>
 
           <div class="flex items-center justify-end gap-2">
+            <template v-if="loan.status === 'pending'">
+              <button
+                :disabled="processingId === loan.id"
+                class="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                @click="setLoanStatus(loan.id, 'active')"
+              >
+                Aprobar
+              </button>
+              <button
+                :disabled="processingId === loan.id"
+                class="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-500 transition disabled:opacity-50"
+                @click="setLoanStatus(loan.id, 'rejected')"
+              >
+                Rechazar
+              </button>
+            </template>
             <button
-              :disabled="processingId === loan.id"
-              class="rounded-lg bg-emerald-600 px-5 py-2 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
-              @click="updateLoan(loan.id, 'active')"
+              v-if="loan.status === 'active' || loan.status === 'paid'"
+              class="rounded-lg bg-blue-600/20 px-3 py-2 text-xs font-semibold text-blue-300 hover:bg-blue-600/30 transition"
+              @click="openPayments(loan)"
             >
-              Aprobar
+              Pagos
             </button>
             <button
-              :disabled="processingId === loan.id"
-              class="rounded-lg bg-red-600 px-5 py-2 text-sm font-semibold text-white hover:bg-red-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
-              @click="updateLoan(loan.id, 'rejected')"
+              class="rounded-lg bg-gray-700 px-3 py-2 text-xs font-semibold text-white hover:bg-gray-600 transition"
+              @click="openEditLoan(loan)"
             >
-              Rechazar
+              Editar
+            </button>
+            <button
+              class="rounded-lg bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-400 hover:bg-red-500/20 transition"
+              @click="askDeleteLoan(loan)"
+            >
+              Eliminar
             </button>
           </div>
         </div>
       </div>
     </template>
+
+    <!-- ==================== MODAL EDITAR APORTE ==================== -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="editingContribution" class="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div class="absolute inset-0 bg-black/60" @click="closeEditContribution" />
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Editar Aporte</h2>
+            <form class="space-y-4" @submit.prevent="saveContribution">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Miembro</label>
+                <select
+                  v-model="editingContribution.profile_id"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option v-for="p in profiles" :key="p.id" :value="p.id">{{ p.full_name }}</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Monto (COP)</label>
+                <input
+                  v-model.number="editingContribution.amount"
+                  type="number"
+                  min="1"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Fecha de depósito</label>
+                <input
+                  v-model="editingContribution.deposit_date"
+                  type="date"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Estado</label>
+                <select
+                  v-model="editingContribution.status"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option value="pending">Pendiente</option>
+                  <option value="approved">Aprobado</option>
+                  <option value="rejected">Rechazado</option>
+                </select>
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="closeEditContribution"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="saving"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ saving ? 'Guardando...' : 'Guardar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <!-- ==================== MODAL EDITAR PRÉSTAMO ==================== -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="editingLoan" class="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div class="absolute inset-0 bg-black/60" @click="closeEditLoan" />
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Editar Préstamo</h2>
+            <form class="space-y-4" @submit.prevent="saveLoan">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Miembro</label>
+                <select
+                  v-model="editingLoan.profile_id"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option v-for="p in profiles" :key="p.id" :value="p.id">{{ p.full_name }}</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Monto solicitado (COP)</label>
+                <input
+                  v-model.number="editingLoan.requested_amount"
+                  type="number"
+                  min="1"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div class="grid grid-cols-2 gap-3">
+                <div>
+                  <label class="block text-sm font-medium text-gray-300 mb-1">Interés (%)</label>
+                  <input
+                    v-model.number="editingLoan.interest_rate"
+                    type="number"
+                    min="0"
+                    step="0.1"
+                    required
+                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                  />
+                </div>
+                <div>
+                  <label class="block text-sm font-medium text-gray-300 mb-1">Cuotas</label>
+                  <input
+                    v-model.number="editingLoan.installments"
+                    type="number"
+                    min="1"
+                    required
+                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                  />
+                </div>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Codeudor</label>
+                <select
+                  v-model="editingLoan.guarantor_id"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option :value="null">Sin codeudor</option>
+                  <option v-for="p in profiles" :key="p.id" :value="p.id">{{ p.full_name }}</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Estado</label>
+                <select
+                  v-model="editingLoan.status"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option value="pending">Pendiente</option>
+                  <option value="active">Activo</option>
+                  <option value="paid">Pagado</option>
+                  <option value="defaulted">En mora</option>
+                  <option value="rejected">Rechazado</option>
+                </select>
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="closeEditLoan"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="saving"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ saving ? 'Guardando...' : 'Guardar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <!-- Modal gestión de pagos -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="paymentsLoan" class="fixed inset-0 z-50 flex items-center justify-center px-4 overflow-y-auto py-8">
+          <div class="absolute inset-0 bg-black/60" @click="closePayments" />
+          <div class="relative w-full max-w-lg bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <div class="flex items-center justify-between mb-5">
+              <div>
+                <h2 class="text-xl font-bold text-white">Pagos del Préstamo</h2>
+                <p class="text-sm text-gray-400 mt-0.5">
+                  {{ paymentsLoan.profiles.full_name }} · {{ formatCOP(paymentsLoan.requested_amount) }}
+                </p>
+              </div>
+              <button class="text-gray-500 hover:text-white transition" @click="closePayments">
+                <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                  <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+                </svg>
+              </button>
+            </div>
+
+            <div v-if="paymentsLoading" class="space-y-2">
+              <div v-for="i in 2" :key="i" class="animate-pulse bg-gray-800 rounded-lg h-12" />
+            </div>
+
+            <div v-else-if="paymentsList.length === 0" class="text-center py-8 text-gray-400 text-sm">
+              No hay pagos registrados para este préstamo.
+            </div>
+
+            <ul v-else class="space-y-2 max-h-96 overflow-y-auto">
+              <li
+                v-for="p in paymentsList"
+                :key="p.id"
+                class="rounded-lg bg-gray-800/50 px-4 py-3"
+              >
+                <template v-if="editingPayment?.id === p.id">
+                  <form class="flex items-center gap-2" @submit.prevent="savePayment">
+                    <input
+                      v-model.number="editingPayment.amount"
+                      type="number"
+                      min="1"
+                      required
+                      class="w-32 rounded border border-gray-700 bg-gray-900 px-3 py-1.5 text-sm text-white outline-none focus:border-emerald-500"
+                    />
+                    <input
+                      v-model="editingPayment.payment_date"
+                      type="date"
+                      required
+                      class="flex-1 rounded border border-gray-700 bg-gray-900 px-3 py-1.5 text-sm text-white outline-none focus:border-emerald-500"
+                    />
+                    <button
+                      type="submit"
+                      :disabled="saving"
+                      class="rounded bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                    >
+                      Guardar
+                    </button>
+                    <button
+                      type="button"
+                      class="rounded bg-gray-700 px-3 py-1.5 text-xs font-semibold text-white hover:bg-gray-600 transition"
+                      @click="editingPayment = null"
+                    >
+                      Cancelar
+                    </button>
+                  </form>
+                </template>
+                <template v-else>
+                  <div class="flex items-center justify-between">
+                    <div>
+                      <p class="text-sm font-semibold text-emerald-400">{{ formatCOP(p.amount) }}</p>
+                      <p class="text-xs text-gray-500">{{ formatDate(p.payment_date) }}</p>
+                    </div>
+                    <div class="flex items-center gap-2">
+                      <button
+                        class="rounded-md bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                        title="Editar"
+                        @click="startEditPayment(p)"
+                      >
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                        </svg>
+                      </button>
+                      <button
+                        class="rounded-md bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
+                        title="Eliminar"
+                        @click="askDeletePayment(p)"
+                      >
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </template>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <!-- Confirmación de borrado -->
+    <ConfirmModal
+      :visible="deleteTarget !== null"
+      title="Eliminar registro"
+      :message="`¿Seguro que quieres eliminar ${deleteTarget?.label ?? ''}? Esta acción no se puede deshacer.`"
+      :loading="deleting"
+      @cancel="deleteTarget = null"
+      @confirm="confirmDelete"
+    />
   </div>
 </template>

--- a/app/pages/admin/inversiones.vue
+++ b/app/pages/admin/inversiones.vue
@@ -1,0 +1,619 @@
+<script setup lang="ts">
+type InvestmentStatus = 'active' | 'completed'
+
+interface Investment {
+  id: string
+  name: string
+  invested_amount: number
+  annual_interest_rate: number
+  start_date: string
+  end_date: string
+  status: InvestmentStatus
+  actual_return: number | null
+  created_at: string
+}
+
+definePageMeta({
+  middleware: 'admin',
+  layout: 'default',
+})
+
+const supabase = useSupabase()
+const toast = useToast()
+const { toLocalDate } = useLocalDate()
+
+const investments = ref<Investment[]>([])
+const loading = ref(true)
+const submitting = ref(false)
+const processingId = ref<string | null>(null)
+
+const finalizingInvestment = ref<Investment | null>(null)
+const finalizeReturn = ref<number | null>(null)
+const finalizeSubmitting = ref(false)
+
+const editing = ref<Investment | null>(null)
+const saving = ref(false)
+const deleteTarget = ref<Investment | null>(null)
+const deleting = ref(false)
+
+const name = ref('')
+const investedAmount = ref<number | null>(null)
+const annualRate = ref<number | null>(null)
+const startDate = ref(toLocalDate())
+const endDate = ref('')
+
+async function loadInvestments() {
+  const { data } = await supabase
+    .from('investments')
+    .select('*')
+    .order('created_at', { ascending: false })
+
+  investments.value = (data as Investment[]) ?? []
+  loading.value = false
+}
+
+function resetForm() {
+  name.value = ''
+  investedAmount.value = null
+  annualRate.value = null
+  startDate.value = toLocalDate()
+  endDate.value = ''
+}
+
+async function handleSubmit() {
+  if (!name.value || !investedAmount.value || annualRate.value === null || !startDate.value || !endDate.value) return
+
+  if (endDate.value < startDate.value) {
+    toast.error('La fecha de vencimiento debe ser posterior a la de inicio.')
+    return
+  }
+
+  submitting.value = true
+
+  const { error } = await supabase.from('investments').insert({
+    name: name.value,
+    invested_amount: investedAmount.value,
+    annual_interest_rate: annualRate.value,
+    start_date: startDate.value,
+    end_date: endDate.value,
+    status: 'active',
+  })
+
+  submitting.value = false
+
+  if (error) {
+    toast.error('Error al registrar la inversión.')
+    return
+  }
+
+  toast.success('Inversión registrada.')
+  resetForm()
+  await loadInvestments()
+}
+
+function openFinalizeModal(inv: Investment) {
+  finalizingInvestment.value = inv
+  finalizeReturn.value = Math.round(projectedInterest(inv))
+}
+
+function closeFinalizeModal() {
+  finalizingInvestment.value = null
+  finalizeReturn.value = null
+}
+
+async function confirmFinalize() {
+  if (!finalizingInvestment.value || finalizeReturn.value === null || finalizeReturn.value < 0) return
+
+  finalizeSubmitting.value = true
+
+  const { error } = await supabase
+    .from('investments')
+    .update({ status: 'completed', actual_return: finalizeReturn.value })
+    .eq('id', finalizingInvestment.value.id)
+
+  finalizeSubmitting.value = false
+
+  if (error) {
+    toast.error('Error al finalizar la inversión.')
+    return
+  }
+
+  toast.success('Inversión finalizada. Rendimiento sumado al capital.')
+  closeFinalizeModal()
+  await loadInvestments()
+}
+
+function openEdit(inv: Investment) {
+  editing.value = { ...inv }
+}
+
+async function saveEdit() {
+  if (!editing.value) return
+  saving.value = true
+  const i = editing.value
+  const { error } = await supabase
+    .from('investments')
+    .update({
+      name: i.name,
+      invested_amount: i.invested_amount,
+      annual_interest_rate: i.annual_interest_rate,
+      start_date: i.start_date,
+      end_date: i.end_date,
+      status: i.status,
+      actual_return: i.actual_return,
+    })
+    .eq('id', i.id)
+  saving.value = false
+  if (error) {
+    toast.error('Error al guardar la inversión.')
+    return
+  }
+  toast.success('Inversión actualizada.')
+  editing.value = null
+  await loadInvestments()
+}
+
+async function confirmDelete() {
+  if (!deleteTarget.value) return
+  deleting.value = true
+  const { error } = await supabase.from('investments').delete().eq('id', deleteTarget.value.id)
+  deleting.value = false
+  if (error) {
+    toast.error(`No se pudo eliminar: ${error.message}`)
+    return
+  }
+  toast.success('Inversión eliminada.')
+  deleteTarget.value = null
+  await loadInvestments()
+}
+
+async function reactivateInvestment(id: string) {
+  processingId.value = id
+
+  const { error } = await supabase
+    .from('investments')
+    .update({ status: 'active', actual_return: null })
+    .eq('id', id)
+
+  processingId.value = null
+
+  if (error) {
+    toast.error('Error al reactivar la inversión.')
+    return
+  }
+
+  toast.success('Inversión reactivada.')
+  await loadInvestments()
+}
+
+function daysBetween(from: string, to: Date): number {
+  const start = new Date(from + 'T00:00:00')
+  const diffMs = to.getTime() - start.getTime()
+  return Math.max(0, Math.floor(diffMs / (1000 * 60 * 60 * 24)))
+}
+
+function accruedInterest(inv: Investment): number {
+  const now = new Date()
+  const end = new Date(inv.end_date + 'T23:59:59')
+  const cutoff = now > end ? end : now
+  const elapsed = daysBetween(inv.start_date, cutoff)
+  return inv.invested_amount * (inv.annual_interest_rate / 100) * (elapsed / 365)
+}
+
+function projectedInterest(inv: Investment): number {
+  const total = daysBetween(inv.start_date, new Date(inv.end_date + 'T23:59:59'))
+  return inv.invested_amount * (inv.annual_interest_rate / 100) * (total / 365)
+}
+
+function formatCOP(value: number): string {
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(value)
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr + 'T12:00:00').toLocaleDateString('es-CO', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+const statusLabel: Record<InvestmentStatus, string> = {
+  active: 'Activa',
+  completed: 'Finalizada',
+}
+
+const statusClasses: Record<InvestmentStatus, string> = {
+  active: 'bg-emerald-500/20 text-emerald-400',
+  completed: 'bg-gray-500/20 text-gray-400',
+}
+
+onMounted(loadInvestments)
+</script>
+
+<template>
+  <div>
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-white">Inversiones Externas</h1>
+      <p class="text-gray-400 mt-1">Registra y gestiona las inversiones del fondo (CDT, fiducias, etc.).</p>
+    </div>
+
+    <!-- Formulario -->
+    <div class="bg-gray-900 rounded-2xl border border-gray-800 p-6 mb-6">
+      <h2 class="text-lg font-semibold text-white mb-4">Nueva Inversión</h2>
+      <form @submit.prevent="handleSubmit" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="md:col-span-2">
+          <label class="block text-sm font-medium text-gray-300 mb-1">Nombre</label>
+          <input
+            v-model="name"
+            type="text"
+            required
+            placeholder="CDT Bancolombia 180 días"
+            class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+          />
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-300 mb-1">Monto invertido (COP)</label>
+          <input
+            v-model.number="investedAmount"
+            type="number"
+            required
+            min="1"
+            step="1"
+            placeholder="1000000"
+            class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+          />
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-300 mb-1">Tasa de interés anual (%)</label>
+          <input
+            v-model.number="annualRate"
+            type="number"
+            required
+            min="0"
+            step="0.01"
+            placeholder="12.5"
+            class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+          />
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-300 mb-1">Fecha de inicio</label>
+          <input
+            v-model="startDate"
+            type="date"
+            required
+            class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+          />
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-300 mb-1">Fecha de vencimiento</label>
+          <input
+            v-model="endDate"
+            type="date"
+            required
+            class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+          />
+        </div>
+
+        <div class="md:col-span-2">
+          <button
+            type="submit"
+            :disabled="submitting"
+            class="rounded-lg bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-gray-900 transition disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {{ submitting ? 'Guardando...' : 'Registrar Inversión' }}
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <!-- Listado -->
+    <div v-if="loading" class="space-y-3">
+      <div
+        v-for="i in 3"
+        :key="i"
+        class="animate-pulse bg-gray-900 rounded-xl h-20 border border-gray-800"
+      />
+    </div>
+
+    <template v-else>
+      <div
+        v-if="investments.length === 0"
+        class="bg-gray-900 rounded-2xl border border-gray-800 p-12 text-center"
+      >
+        <p class="text-gray-400 text-lg">Aún no hay inversiones registradas.</p>
+      </div>
+
+      <div v-else class="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
+        <table class="w-full">
+          <thead>
+            <tr class="border-b border-gray-800">
+              <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Nombre</th>
+              <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Monto</th>
+              <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Tasa</th>
+              <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Rendimiento</th>
+              <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Vigencia</th>
+              <th class="text-center text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Estado</th>
+              <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Acción</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="inv in investments"
+              :key="inv.id"
+              class="border-b border-gray-800/50 last:border-0 hover:bg-gray-800/30 transition"
+            >
+              <td class="px-6 py-4">
+                <span class="text-sm font-medium text-white">{{ inv.name }}</span>
+              </td>
+              <td class="px-6 py-4 text-right">
+                <span class="text-sm font-semibold text-white">{{ formatCOP(inv.invested_amount) }}</span>
+              </td>
+              <td class="px-6 py-4 text-right">
+                <span class="text-sm text-gray-300">{{ inv.annual_interest_rate }}%</span>
+              </td>
+              <td class="px-6 py-4 text-right">
+                <template v-if="inv.status === 'completed' && inv.actual_return !== null">
+                  <p class="text-sm font-semibold text-emerald-400">+{{ formatCOP(inv.actual_return) }}</p>
+                  <p class="text-[11px] text-gray-500 mt-0.5">Rendimiento real obtenido</p>
+                </template>
+                <template v-else>
+                  <p class="text-sm font-semibold text-emerald-400">+{{ formatCOP(accruedInterest(inv)) }}</p>
+                  <p class="text-[11px] text-gray-500 mt-0.5">
+                    Proyectado: {{ formatCOP(projectedInterest(inv)) }}
+                  </p>
+                </template>
+              </td>
+              <td class="px-6 py-4">
+                <span class="text-xs text-gray-400">
+                  {{ formatDate(inv.start_date) }} → {{ formatDate(inv.end_date) }}
+                </span>
+              </td>
+              <td class="px-6 py-4 text-center">
+                <span
+                  class="px-2 py-0.5 text-xs font-medium rounded-full"
+                  :class="statusClasses[inv.status]"
+                >
+                  {{ statusLabel[inv.status] }}
+                </span>
+              </td>
+              <td class="px-6 py-4 text-right">
+                <div class="flex items-center justify-end gap-2">
+                  <button
+                    v-if="inv.status === 'active'"
+                    class="rounded-lg bg-gray-700 px-3 py-1.5 text-xs font-semibold text-white hover:bg-gray-600 transition"
+                    @click="openFinalizeModal(inv)"
+                  >
+                    Finalizar
+                  </button>
+                  <button
+                    v-else
+                    :disabled="processingId === inv.id"
+                    class="rounded-lg bg-emerald-700 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-600 transition disabled:opacity-50"
+                    @click="reactivateInvestment(inv.id)"
+                  >
+                    Reactivar
+                  </button>
+                  <button
+                    class="rounded-lg bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                    title="Editar"
+                    @click="openEdit(inv)"
+                  >
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                    </svg>
+                  </button>
+                  <button
+                    class="rounded-lg bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
+                    title="Eliminar"
+                    @click="deleteTarget = inv"
+                  >
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+
+    <!-- Modal de finalización -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div
+          v-if="finalizingInvestment"
+          class="fixed inset-0 z-50 flex items-center justify-center px-4"
+        >
+          <div class="absolute inset-0 bg-black/60" @click="closeFinalizeModal" />
+
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <div class="flex items-center justify-between mb-6">
+              <h2 class="text-xl font-bold text-white">Finalizar Inversión</h2>
+              <button class="text-gray-500 hover:text-white transition" @click="closeFinalizeModal">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                  <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+                </svg>
+              </button>
+            </div>
+
+            <div class="mb-5 rounded-lg bg-gray-800/50 px-4 py-3">
+              <p class="text-xs text-gray-400 uppercase tracking-wider">{{ finalizingInvestment.name }}</p>
+              <p class="text-lg font-bold text-white mt-1">{{ formatCOP(finalizingInvestment.invested_amount) }}</p>
+              <p class="text-xs text-gray-500 mt-1">
+                Tasa {{ finalizingInvestment.annual_interest_rate }}% · Proyectado: {{ formatCOP(projectedInterest(finalizingInvestment)) }}
+              </p>
+            </div>
+
+            <form @submit.prevent="confirmFinalize" class="space-y-5">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">
+                  Rendimiento real obtenido (COP)
+                </label>
+                <input
+                  v-model.number="finalizeReturn"
+                  type="number"
+                  required
+                  min="0"
+                  step="1"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+                />
+                <p class="text-xs text-gray-500 mt-1">
+                  Ajusta el monto al rendimiento real pagado por el banco. El capital invertido vuelve a Caja automáticamente.
+                </p>
+              </div>
+
+              <div class="flex gap-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="closeFinalizeModal"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="finalizeSubmitting || finalizeReturn === null || finalizeReturn < 0"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {{ finalizeSubmitting ? 'Guardando...' : 'Confirmar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <!-- Modal editar inversión -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="editing" class="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div class="absolute inset-0 bg-black/60" @click="editing = null" />
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Editar Inversión</h2>
+            <form class="space-y-4" @submit.prevent="saveEdit">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Nombre</label>
+                <input
+                  v-model="editing.name"
+                  type="text"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Monto invertido (COP)</label>
+                <input
+                  v-model.number="editing.invested_amount"
+                  type="number"
+                  min="1"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Tasa de interés anual (%)</label>
+                <input
+                  v-model.number="editing.annual_interest_rate"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div class="grid grid-cols-2 gap-3">
+                <div>
+                  <label class="block text-sm font-medium text-gray-300 mb-1">Inicio</label>
+                  <input
+                    v-model="editing.start_date"
+                    type="date"
+                    required
+                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                  />
+                </div>
+                <div>
+                  <label class="block text-sm font-medium text-gray-300 mb-1">Vencimiento</label>
+                  <input
+                    v-model="editing.end_date"
+                    type="date"
+                    required
+                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                  />
+                </div>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Estado</label>
+                <select
+                  v-model="editing.status"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option value="active">Activa</option>
+                  <option value="completed">Finalizada</option>
+                </select>
+              </div>
+              <div v-if="editing.status === 'completed'">
+                <label class="block text-sm font-medium text-gray-300 mb-1">Rendimiento real (COP)</label>
+                <input
+                  v-model.number="editing.actual_return"
+                  type="number"
+                  min="0"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="editing = null"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="saving"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ saving ? 'Guardando...' : 'Guardar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <ConfirmModal
+      :visible="deleteTarget !== null"
+      title="Eliminar inversión"
+      :message="deleteTarget ? `¿Seguro que quieres eliminar la inversión \&quot;${deleteTarget.name}\&quot;? Esta acción no se puede deshacer.` : ''"
+      :loading="deleting"
+      @cancel="deleteTarget = null"
+      @confirm="confirmDelete"
+    />
+  </div>
+</template>

--- a/app/pages/admin/miembros.vue
+++ b/app/pages/admin/miembros.vue
@@ -1,0 +1,411 @@
+<script setup lang="ts">
+interface AdminProfile {
+  id: string
+  full_name: string
+  role: 'admin' | 'member'
+  phone: string | null
+  created_at: string
+}
+
+definePageMeta({
+  middleware: 'admin',
+  layout: 'default',
+})
+
+const supabase = useSupabase()
+const toast = useToast()
+
+const profiles = ref<AdminProfile[]>([])
+const loading = ref(true)
+const editing = ref<AdminProfile | null>(null)
+const saving = ref(false)
+const deleteTarget = ref<AdminProfile | null>(null)
+const deleting = ref(false)
+
+// Creación
+interface NewMemberForm {
+  email: string
+  password: string
+  full_name: string
+  phone: string
+  role: 'admin' | 'member'
+}
+const creating = ref<NewMemberForm | null>(null)
+const creatingSubmitting = ref(false)
+
+function openCreate() {
+  creating.value = {
+    email: '',
+    password: '',
+    full_name: '',
+    phone: '',
+    role: 'member',
+  }
+}
+
+async function submitCreate() {
+  if (!creating.value) return
+  const form = creating.value
+
+  if (form.password.length < 6) {
+    toast.error('La contraseña debe tener al menos 6 caracteres.')
+    return
+  }
+
+  creatingSubmitting.value = true
+
+  // 1. Guardar la sesión del admin antes de crear el usuario (signUp la reemplaza).
+  const { data: { session: adminSession } } = await supabase.auth.getSession()
+
+  // 2. Crear el usuario en auth.users via signUp.
+  const { data: signUpData, error: signUpError } = await supabase.auth.signUp({
+    email: form.email.trim(),
+    password: form.password,
+  })
+
+  if (signUpError || !signUpData.user) {
+    creatingSubmitting.value = false
+    toast.error(`Error al crear el usuario: ${signUpError?.message ?? 'desconocido'}`)
+    return
+  }
+
+  // 3. Insertar la fila en profiles (con la sesión del nuevo usuario — el insert policy lo permite).
+  const { error: profileError } = await supabase.from('profiles').insert({
+    id: signUpData.user.id,
+    full_name: form.full_name.trim(),
+    phone: form.phone.trim() || null,
+    role: form.role,
+  })
+
+  // 4. Restaurar la sesión del admin sí o sí.
+  if (adminSession) {
+    await supabase.auth.setSession({
+      access_token: adminSession.access_token,
+      refresh_token: adminSession.refresh_token,
+    })
+  }
+
+  creatingSubmitting.value = false
+
+  if (profileError) {
+    toast.error(`Usuario creado pero falló el perfil: ${profileError.message}`)
+    return
+  }
+
+  toast.success(`Miembro ${form.full_name} creado correctamente.`)
+  creating.value = null
+  await loadProfiles()
+}
+
+async function loadProfiles() {
+  loading.value = true
+  const { data } = await supabase
+    .from('profiles')
+    .select('id, full_name, role, phone, created_at')
+    .order('full_name')
+  profiles.value = (data as AdminProfile[]) ?? []
+  loading.value = false
+}
+
+function openEdit(p: AdminProfile) {
+  editing.value = { ...p }
+}
+
+async function saveEdit() {
+  if (!editing.value) return
+  saving.value = true
+  const p = editing.value
+  const { error } = await supabase
+    .from('profiles')
+    .update({
+      full_name: p.full_name,
+      role: p.role,
+      phone: p.phone || null,
+    })
+    .eq('id', p.id)
+  saving.value = false
+  if (error) {
+    toast.error('Error al guardar el miembro.')
+    return
+  }
+  toast.success('Miembro actualizado.')
+  editing.value = null
+  await loadProfiles()
+}
+
+async function confirmDelete() {
+  if (!deleteTarget.value) return
+  deleting.value = true
+  const { error } = await supabase.from('profiles').delete().eq('id', deleteTarget.value.id)
+  deleting.value = false
+  if (error) {
+    toast.error(
+      `No se pudo eliminar: ${error.message}. Revisa que no tenga aportes, préstamos, retiros o multas asociadas.`,
+    )
+    return
+  }
+  toast.success('Miembro eliminado.')
+  deleteTarget.value = null
+  await loadProfiles()
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('es-CO', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+onMounted(loadProfiles)
+</script>
+
+<template>
+  <div>
+    <div class="mb-8 flex items-start justify-between gap-4">
+      <div>
+        <h1 class="text-2xl font-bold text-white">Miembros</h1>
+        <p class="text-gray-400 mt-1">Gestión de perfiles y roles del fondo.</p>
+      </div>
+      <button
+        class="shrink-0 rounded-lg bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition"
+        @click="openCreate"
+      >
+        + Nuevo Miembro
+      </button>
+    </div>
+
+    <div v-if="loading" class="space-y-3">
+      <div v-for="i in 4" :key="i" class="animate-pulse bg-gray-900 rounded-xl h-16 border border-gray-800" />
+    </div>
+
+    <template v-else>
+      <div
+        v-if="profiles.length === 0"
+        class="bg-gray-900 rounded-2xl border border-gray-800 p-12 text-center"
+      >
+        <p class="text-gray-400 text-lg">No hay miembros registrados.</p>
+      </div>
+
+      <div v-else class="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
+        <table class="w-full">
+          <thead>
+            <tr class="border-b border-gray-800">
+              <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Nombre</th>
+              <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Teléfono</th>
+              <th class="text-center text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Rol</th>
+              <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Alta</th>
+              <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="p in profiles"
+              :key="p.id"
+              class="border-b border-gray-800/50 last:border-0 hover:bg-gray-800/30 transition"
+            >
+              <td class="px-6 py-4"><span class="text-sm font-medium text-white">{{ p.full_name }}</span></td>
+              <td class="px-6 py-4"><span class="text-sm text-gray-300">{{ p.phone ?? '—' }}</span></td>
+              <td class="px-6 py-4 text-center">
+                <span
+                  class="px-2 py-0.5 text-xs font-medium rounded-full"
+                  :class="p.role === 'admin'
+                    ? 'bg-emerald-500/20 text-emerald-400'
+                    : 'bg-blue-500/20 text-blue-400'"
+                >
+                  {{ p.role === 'admin' ? 'Administrador' : 'Miembro' }}
+                </span>
+              </td>
+              <td class="px-6 py-4"><span class="text-sm text-gray-400">{{ formatDate(p.created_at) }}</span></td>
+              <td class="px-6 py-4">
+                <div class="flex items-center justify-end gap-2">
+                  <button
+                    class="rounded-lg bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                    title="Editar"
+                    @click="openEdit(p)"
+                  >
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                    </svg>
+                  </button>
+                  <button
+                    class="rounded-lg bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
+                    title="Eliminar"
+                    @click="deleteTarget = p"
+                  >
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+
+    <!-- Modal editar -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="editing" class="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div class="absolute inset-0 bg-black/60" @click="editing = null" />
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Editar Miembro</h2>
+            <form class="space-y-4" @submit.prevent="saveEdit">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Nombre completo</label>
+                <input
+                  v-model="editing.full_name"
+                  type="text"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Teléfono</label>
+                <input
+                  v-model="editing.phone"
+                  type="text"
+                  placeholder="300 000 0000"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Rol</label>
+                <select
+                  v-model="editing.role"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option value="member">Miembro</option>
+                  <option value="admin">Administrador</option>
+                </select>
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="editing = null"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="saving"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ saving ? 'Guardando...' : 'Guardar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <!-- Modal crear miembro -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="creating" class="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div class="absolute inset-0 bg-black/60" @click="creating = null" />
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Nuevo Miembro</h2>
+            <form class="space-y-4" @submit.prevent="submitCreate">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Nombre completo</label>
+                <input
+                  v-model="creating.full_name"
+                  type="text"
+                  required
+                  placeholder="María Pérez"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Correo electrónico</label>
+                <input
+                  v-model="creating.email"
+                  type="email"
+                  required
+                  placeholder="maria@fodaf.local"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Contraseña inicial</label>
+                <input
+                  v-model="creating.password"
+                  type="text"
+                  required
+                  minlength="6"
+                  placeholder="mínimo 6 caracteres"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+                <p class="text-xs text-gray-500 mt-1">El miembro podrá cambiarla después desde su perfil.</p>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Teléfono</label>
+                <input
+                  v-model="creating.phone"
+                  type="text"
+                  placeholder="300 000 0000"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Rol</label>
+                <select
+                  v-model="creating.role"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option value="member">Miembro</option>
+                  <option value="admin">Administrador</option>
+                </select>
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  :disabled="creatingSubmitting"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition disabled:opacity-50"
+                  @click="creating = null"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="creatingSubmitting"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ creatingSubmitting ? 'Creando...' : 'Crear Miembro' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <ConfirmModal
+      :visible="deleteTarget !== null"
+      title="Eliminar miembro"
+      :message="deleteTarget ? `¿Seguro que quieres eliminar a ${deleteTarget.full_name}? Fallará si tiene aportes, préstamos, retiros o multas asociadas.` : ''"
+      :loading="deleting"
+      @cancel="deleteTarget = null"
+      @confirm="confirmDelete"
+    />
+  </div>
+</template>

--- a/app/pages/admin/retiros.vue
+++ b/app/pages/admin/retiros.vue
@@ -1,0 +1,310 @@
+<script setup lang="ts">
+interface ProfileOption {
+  id: string
+  full_name: string
+}
+
+interface AdminWithdrawal {
+  id: string
+  profile_id: string
+  amount: number
+  status: 'pending' | 'approved' | 'rejected'
+  created_at: string
+  profiles: { full_name: string }
+}
+
+definePageMeta({
+  middleware: 'admin',
+  layout: 'default',
+})
+
+const supabase = useSupabase()
+const toast = useToast()
+
+const withdrawals = ref<AdminWithdrawal[]>([])
+const profiles = ref<ProfileOption[]>([])
+const loading = ref(true)
+const processingId = ref<string | null>(null)
+const filter = ref<'all' | 'pending' | 'approved' | 'rejected'>('pending')
+
+const editing = ref<AdminWithdrawal | null>(null)
+const saving = ref(false)
+const deleteTarget = ref<AdminWithdrawal | null>(null)
+const deleting = ref(false)
+
+async function loadData() {
+  loading.value = true
+  const [wResult, pResult] = await Promise.all([
+    supabase
+      .from('withdrawals')
+      .select('id, profile_id, amount, status, created_at, profiles(full_name)')
+      .order('created_at', { ascending: false }),
+    supabase.from('profiles').select('id, full_name').order('full_name'),
+  ])
+  withdrawals.value = (wResult.data as unknown as AdminWithdrawal[]) ?? []
+  profiles.value = (pResult.data as unknown as ProfileOption[]) ?? []
+  loading.value = false
+}
+
+const filteredWithdrawals = computed(() =>
+  filter.value === 'all' ? withdrawals.value : withdrawals.value.filter(w => w.status === filter.value),
+)
+
+async function setStatus(id: string, status: 'approved' | 'rejected') {
+  processingId.value = id
+  const { error } = await supabase.from('withdrawals').update({ status }).eq('id', id)
+  processingId.value = null
+  if (error) {
+    toast.error('Error al actualizar el retiro.')
+    return
+  }
+  toast.success(status === 'approved' ? 'Retiro aprobado.' : 'Retiro rechazado.')
+  await loadData()
+}
+
+function openEdit(w: AdminWithdrawal) {
+  editing.value = { ...w }
+}
+
+async function saveEdit() {
+  if (!editing.value) return
+  saving.value = true
+  const w = editing.value
+  const { error } = await supabase
+    .from('withdrawals')
+    .update({ profile_id: w.profile_id, amount: w.amount, status: w.status })
+    .eq('id', w.id)
+  saving.value = false
+  if (error) {
+    toast.error('Error al guardar el retiro.')
+    return
+  }
+  toast.success('Retiro actualizado.')
+  editing.value = null
+  await loadData()
+}
+
+async function confirmDelete() {
+  if (!deleteTarget.value) return
+  deleting.value = true
+  const { error } = await supabase.from('withdrawals').delete().eq('id', deleteTarget.value.id)
+  deleting.value = false
+  if (error) {
+    toast.error(`No se pudo eliminar: ${error.message}`)
+    return
+  }
+  toast.success('Retiro eliminado.')
+  deleteTarget.value = null
+  await loadData()
+}
+
+function formatCOP(value: number): string {
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(value)
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('es-CO', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+const statusLabels: Record<string, string> = {
+  pending: 'Pendiente',
+  approved: 'Aprobado',
+  rejected: 'Rechazado',
+}
+
+const statusClasses: Record<string, string> = {
+  pending: 'bg-yellow-500/20 text-yellow-400',
+  approved: 'bg-emerald-500/20 text-emerald-400',
+  rejected: 'bg-red-500/20 text-red-400',
+}
+
+onMounted(loadData)
+</script>
+
+<template>
+  <div>
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-white">Solicitudes de Retiro</h1>
+      <p class="text-gray-400 mt-1">Gestiona los retiros solicitados por los miembros.</p>
+    </div>
+
+    <div class="flex gap-2 mb-4">
+      <button
+        v-for="f in (['pending', 'approved', 'rejected', 'all'] as const)"
+        :key="f"
+        class="px-3 py-1.5 text-xs font-medium rounded-lg border transition"
+        :class="filter === f
+          ? 'border-emerald-500 bg-emerald-500/20 text-emerald-400'
+          : 'border-gray-700 bg-gray-800 text-gray-400 hover:border-gray-600'"
+        @click="filter = f"
+      >
+        {{ f === 'all' ? 'Todos' : statusLabels[f] }}
+      </button>
+    </div>
+
+    <div v-if="loading" class="space-y-3">
+      <div v-for="i in 3" :key="i" class="animate-pulse bg-gray-900 rounded-xl h-20 border border-gray-800" />
+    </div>
+
+    <template v-else>
+      <div
+        v-if="filteredWithdrawals.length === 0"
+        class="bg-gray-900 rounded-2xl border border-gray-800 p-12 text-center"
+      >
+        <p class="text-gray-400 text-lg">No hay retiros para mostrar.</p>
+      </div>
+
+      <div v-else class="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
+        <table class="w-full">
+          <thead>
+            <tr class="border-b border-gray-800">
+              <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Miembro</th>
+              <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Fecha</th>
+              <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Monto</th>
+              <th class="text-center text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Estado</th>
+              <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="w in filteredWithdrawals"
+              :key="w.id"
+              class="border-b border-gray-800/50 last:border-0 hover:bg-gray-800/30 transition"
+            >
+              <td class="px-6 py-4"><span class="text-sm font-medium text-white">{{ w.profiles.full_name }}</span></td>
+              <td class="px-6 py-4"><span class="text-sm text-gray-300">{{ formatDate(w.created_at) }}</span></td>
+              <td class="px-6 py-4 text-right"><span class="text-sm font-semibold text-white">{{ formatCOP(w.amount) }}</span></td>
+              <td class="px-6 py-4 text-center">
+                <span class="px-2 py-0.5 text-xs font-medium rounded-full" :class="statusClasses[w.status]">
+                  {{ statusLabels[w.status] }}
+                </span>
+              </td>
+              <td class="px-6 py-4">
+                <div class="flex items-center justify-end gap-2">
+                  <template v-if="w.status === 'pending'">
+                    <button
+                      :disabled="processingId === w.id"
+                      class="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                      @click="setStatus(w.id, 'approved')"
+                    >
+                      Aprobar
+                    </button>
+                    <button
+                      :disabled="processingId === w.id"
+                      class="rounded-lg bg-red-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-red-500 transition disabled:opacity-50"
+                      @click="setStatus(w.id, 'rejected')"
+                    >
+                      Rechazar
+                    </button>
+                  </template>
+                  <button
+                    class="rounded-lg bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                    title="Editar"
+                    @click="openEdit(w)"
+                  >
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                    </svg>
+                  </button>
+                  <button
+                    class="rounded-lg bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
+                    title="Eliminar"
+                    @click="deleteTarget = w"
+                  >
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+
+    <!-- Modal editar -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="editing" class="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div class="absolute inset-0 bg-black/60" @click="editing = null" />
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Editar Retiro</h2>
+            <form class="space-y-4" @submit.prevent="saveEdit">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Miembro</label>
+                <select
+                  v-model="editing.profile_id"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option v-for="p in profiles" :key="p.id" :value="p.id">{{ p.full_name }}</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Monto (COP)</label>
+                <input
+                  v-model.number="editing.amount"
+                  type="number"
+                  min="1"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Estado</label>
+                <select
+                  v-model="editing.status"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option value="pending">Pendiente</option>
+                  <option value="approved">Aprobado</option>
+                  <option value="rejected">Rechazado</option>
+                </select>
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="editing = null"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="saving"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ saving ? 'Guardando...' : 'Guardar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <ConfirmModal
+      :visible="deleteTarget !== null"
+      title="Eliminar retiro"
+      :message="deleteTarget ? `¿Seguro que quieres eliminar el retiro de ${deleteTarget.profiles.full_name} (${formatCOP(deleteTarget.amount)})? Esta acción no se puede deshacer.` : ''"
+      :loading="deleting"
+      @cancel="deleteTarget = null"
+      @confirm="confirmDelete"
+    />
+  </div>
+</template>

--- a/app/pages/admin/reuniones.vue
+++ b/app/pages/admin/reuniones.vue
@@ -1,18 +1,21 @@
 <script setup lang="ts">
+interface PenaltyRow {
+  id: string
+  profile_id: string
+  amount: number
+  reason: 'absence' | 'late_arrival' | 'other'
+  status: 'pending' | 'paid' | 'deducted_from_savings'
+  profiles: {
+    full_name: string
+  }
+}
+
 interface Meeting {
   id: string
   topic: string
   meeting_date: string
   created_at: string
-  penalties: {
-    id: string
-    amount: number
-    reason: string
-    status: string
-    profiles: {
-      full_name: string
-    }
-  }[]
+  penalties: PenaltyRow[]
 }
 
 interface ProfileOption {
@@ -43,19 +46,28 @@ const penaltyModalVisible = ref(false)
 const selectedMeetingId = ref('')
 const processingPenaltyId = ref<string | null>(null)
 
+// Edición inline
+const editingMeeting = ref<Meeting | null>(null)
+const editingPenalty = ref<(PenaltyRow & { meeting_id: string }) | null>(null)
+const saving = ref(false)
+
+// Borrado
+const deleteTarget = ref<{ kind: 'meeting' | 'penalty'; id: string; label: string } | null>(null)
+const deleting = ref(false)
+
 async function loadData() {
   const [meetingsResult, membersResult] = await Promise.all([
     supabase
       .from('meetings')
-      .select('id, topic, meeting_date, created_at, penalties(id, amount, reason, status, profiles(full_name))')
+      .select('id, topic, meeting_date, created_at, penalties(id, profile_id, amount, reason, status, profiles(full_name))')
       .order('meeting_date', { ascending: false }),
     supabase
       .from('profiles')
       .select('id, full_name'),
   ])
 
-  meetings.value = (meetingsResult.data as Meeting[]) ?? []
-  members.value = (membersResult.data as ProfileOption[]) ?? []
+  meetings.value = (meetingsResult.data as unknown as Meeting[]) ?? []
+  members.value = (membersResult.data as unknown as ProfileOption[]) ?? []
   loading.value = false
 }
 
@@ -111,6 +123,87 @@ const statusLabels: Record<string, string> = {
 function openPenaltyModal(meetingId: string) {
   selectedMeetingId.value = meetingId
   penaltyModalVisible.value = true
+}
+
+function openEditMeeting(m: Meeting) {
+  editingMeeting.value = {
+    ...m,
+    meeting_date: toLocalDatetime(new Date(m.meeting_date)),
+  }
+}
+
+async function saveMeeting() {
+  if (!editingMeeting.value) return
+  saving.value = true
+  const { error } = await supabase
+    .from('meetings')
+    .update({
+      topic: editingMeeting.value.topic,
+      meeting_date: editingMeeting.value.meeting_date,
+    })
+    .eq('id', editingMeeting.value.id)
+  saving.value = false
+  if (error) {
+    toast.error('Error al guardar la reunión.')
+    return
+  }
+  toast.success('Reunión actualizada.')
+  editingMeeting.value = null
+  await loadData()
+}
+
+function openEditPenalty(p: PenaltyRow, meetingId: string) {
+  editingPenalty.value = { ...p, meeting_id: meetingId }
+}
+
+async function savePenalty() {
+  if (!editingPenalty.value) return
+  saving.value = true
+  const p = editingPenalty.value
+  const { error } = await supabase
+    .from('penalties')
+    .update({
+      profile_id: p.profile_id,
+      amount: p.amount,
+      reason: p.reason,
+      status: p.status,
+    })
+    .eq('id', p.id)
+  saving.value = false
+  if (error) {
+    toast.error('Error al guardar la multa.')
+    return
+  }
+  toast.success('Multa actualizada.')
+  editingPenalty.value = null
+  await loadData()
+}
+
+function askDeleteMeeting(m: Meeting) {
+  deleteTarget.value = { kind: 'meeting', id: m.id, label: `la reunión "${m.topic}"` }
+}
+
+function askDeletePenalty(p: PenaltyRow) {
+  deleteTarget.value = {
+    kind: 'penalty',
+    id: p.id,
+    label: `la multa de ${p.profiles.full_name} (${formatCOP(p.amount)})`,
+  }
+}
+
+async function confirmDelete() {
+  if (!deleteTarget.value) return
+  deleting.value = true
+  const table = deleteTarget.value.kind === 'meeting' ? 'meetings' : 'penalties'
+  const { error } = await supabase.from(table).delete().eq('id', deleteTarget.value.id)
+  deleting.value = false
+  if (error) {
+    toast.error(`No se pudo eliminar: ${error.message}`)
+    return
+  }
+  toast.success('Registro eliminado.')
+  deleteTarget.value = null
+  await loadData()
 }
 
 const reasonLabels: Record<string, string> = {
@@ -213,12 +306,32 @@ onMounted(loadData)
             <h3 class="text-lg font-semibold text-white">{{ meeting.topic }}</h3>
             <p class="text-sm text-gray-400 mt-0.5">{{ formatDateTime(meeting.meeting_date) }}</p>
           </div>
-          <button
-            class="shrink-0 rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-500 transition"
-            @click="openPenaltyModal(meeting.id)"
-          >
-            + Registrar Multa
-          </button>
+          <div class="flex items-center gap-2 shrink-0">
+            <button
+              class="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-500 transition"
+              @click="openPenaltyModal(meeting.id)"
+            >
+              + Registrar Multa
+            </button>
+            <button
+              class="rounded-lg bg-gray-700 p-2 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+              title="Editar reunión"
+              @click="openEditMeeting(meeting)"
+            >
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+              </svg>
+            </button>
+            <button
+              class="rounded-lg bg-red-500/10 p-2 text-red-400 hover:bg-red-500/20 transition"
+              title="Eliminar reunión"
+              @click="askDeleteMeeting(meeting)"
+            >
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+              </svg>
+            </button>
+          </div>
         </div>
 
         <!-- Multas de esta reunión -->
@@ -250,7 +363,7 @@ onMounted(loadData)
                   {{ statusLabels[penalty.status] ?? penalty.status }}
                 </span>
               </div>
-              <div class="flex items-center gap-3">
+              <div class="flex items-center gap-2">
                 <span class="text-sm font-semibold text-red-400">{{ formatCOP(penalty.amount) }}</span>
                 <template v-if="penalty.status === 'pending'">
                   <button
@@ -268,6 +381,24 @@ onMounted(loadData)
                     Descontar
                   </button>
                 </template>
+                <button
+                  class="rounded-md bg-gray-700 p-1 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                  title="Editar multa"
+                  @click="openEditPenalty(penalty, meeting.id)"
+                >
+                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                  </svg>
+                </button>
+                <button
+                  class="rounded-md bg-red-500/10 p-1 text-red-400 hover:bg-red-500/20 transition"
+                  title="Eliminar multa"
+                  @click="askDeletePenalty(penalty)"
+                >
+                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                  </svg>
+                </button>
               </div>
             </div>
           </div>
@@ -284,6 +415,148 @@ onMounted(loadData)
       :members="members"
       @close="penaltyModalVisible = false"
       @saved="loadData"
+    />
+
+    <!-- Modal editar reunión -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="editingMeeting" class="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div class="absolute inset-0 bg-black/60" @click="editingMeeting = null" />
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Editar Reunión</h2>
+            <form class="space-y-4" @submit.prevent="saveMeeting">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Tema</label>
+                <input
+                  v-model="editingMeeting.topic"
+                  type="text"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Fecha y hora</label>
+                <input
+                  v-model="editingMeeting.meeting_date"
+                  type="datetime-local"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="editingMeeting = null"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="saving"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ saving ? 'Guardando...' : 'Guardar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <!-- Modal editar multa -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="editingPenalty" class="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div class="absolute inset-0 bg-black/60" @click="editingPenalty = null" />
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Editar Multa</h2>
+            <form class="space-y-4" @submit.prevent="savePenalty">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Miembro</label>
+                <select
+                  v-model="editingPenalty.profile_id"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option v-for="m in members" :key="m.id" :value="m.id">{{ m.full_name }}</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Motivo</label>
+                <select
+                  v-model="editingPenalty.reason"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option value="absence">Inasistencia</option>
+                  <option value="late_arrival">Llegada tarde</option>
+                  <option value="other">Otro</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Monto (COP)</label>
+                <input
+                  v-model.number="editingPenalty.amount"
+                  type="number"
+                  min="1"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Estado</label>
+                <select
+                  v-model="editingPenalty.status"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                >
+                  <option value="pending">Pendiente</option>
+                  <option value="paid">Pagada</option>
+                  <option value="deducted_from_savings">Descontada</option>
+                </select>
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="editingPenalty = null"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="saving"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ saving ? 'Guardando...' : 'Guardar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <ConfirmModal
+      :visible="deleteTarget !== null"
+      title="Eliminar registro"
+      :message="`¿Seguro que quieres eliminar ${deleteTarget?.label ?? ''}? Esta acción no se puede deshacer.`"
+      :loading="deleting"
+      @cancel="deleteTarget = null"
+      @confirm="confirmDelete"
     />
   </div>
 </template>

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -9,17 +9,22 @@ const supabase = useSupabase()
 const profileName = ref('')
 const totalApproved = ref(0)
 const totalDeducted = ref(0)
+const totalWithdrawn = ref(0)
+const allWithdrawals = ref<{ amount: number; status: string; created_at: string }[]>([])
+const activeInvestments = ref<{ name: string; invested_amount: number; annual_interest_rate: number; start_date: string; end_date: string }[]>([])
 const allContributions = ref<{ amount: number; deposit_date: string; status: string }[]>([])
 const pendingPenalties = ref<{ amount: number; reason: string }[]>([])
 const loading = ref(true)
 const showModal = ref(false)
+const showWithdrawalModal = ref(false)
 const showHistory = ref(false)
+const showWithdrawalsHistory = ref(false)
 
 async function loadData() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return
 
-  const [profileResult, approvedResult, allContribResult, deductedResult, pendingPenaltiesResult] = await Promise.all([
+  const [profileResult, approvedResult, allContribResult, deductedResult, pendingPenaltiesResult, withdrawalsResult, investmentsResult] = await Promise.all([
     supabase
       .from('profiles')
       .select('full_name')
@@ -45,6 +50,16 @@ async function loadData() {
       .select('amount, reason')
       .eq('profile_id', user.id)
       .eq('status', 'pending'),
+    supabase
+      .from('withdrawals')
+      .select('amount, status, created_at')
+      .eq('profile_id', user.id)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('investments')
+      .select('name, invested_amount, annual_interest_rate, start_date, end_date')
+      .eq('status', 'active')
+      .order('created_at', { ascending: false }),
   ])
 
   if (profileResult.data) {
@@ -59,12 +74,46 @@ async function loadData() {
     ? deductedResult.data.reduce((sum, p) => sum + p.amount, 0)
     : 0
 
+  allWithdrawals.value = withdrawalsResult.data ?? []
+
+  totalWithdrawn.value = allWithdrawals.value
+    .filter(w => w.status === 'approved')
+    .reduce((sum, w) => sum + w.amount, 0)
+
   allContributions.value = allContribResult.data ?? []
   pendingPenalties.value = pendingPenaltiesResult.data ?? []
+  activeInvestments.value = investmentsResult.data ?? []
   loading.value = false
 }
 
-const totalSavings = computed(() => Math.max(0, totalApproved.value - totalDeducted.value))
+const totalInvested = computed(() =>
+  activeInvestments.value.reduce((sum, i) => sum + i.invested_amount, 0),
+)
+
+function daysBetween(from: string, to: Date): number {
+  const start = new Date(from + 'T00:00:00')
+  const diffMs = to.getTime() - start.getTime()
+  return Math.max(0, Math.floor(diffMs / (1000 * 60 * 60 * 24)))
+}
+
+function accruedInterest(inv: { invested_amount: number; annual_interest_rate: number; start_date: string; end_date: string }): number {
+  const now = new Date()
+  const end = new Date(inv.end_date + 'T23:59:59')
+  const cutoff = now > end ? end : now
+  const elapsed = daysBetween(inv.start_date, cutoff)
+  return inv.invested_amount * (inv.annual_interest_rate / 100) * (elapsed / 365)
+}
+
+function projectedInterest(inv: { invested_amount: number; annual_interest_rate: number; start_date: string; end_date: string }): number {
+  const total = daysBetween(inv.start_date, new Date(inv.end_date + 'T23:59:59'))
+  return inv.invested_amount * (inv.annual_interest_rate / 100) * (total / 365)
+}
+
+const totalAccruedInterest = computed(() =>
+  activeInvestments.value.reduce((sum, i) => sum + accruedInterest(i), 0),
+)
+
+const totalSavings = computed(() => Math.max(0, totalApproved.value - totalDeducted.value - totalWithdrawn.value))
 
 const pendingContributions = computed(() =>
   allContributions.value.filter(c => c.status === 'pending'),
@@ -107,6 +156,10 @@ function formatDate(dateStr: string): string {
 }
 
 async function onContributionSaved() {
+  await loadData()
+}
+
+async function onWithdrawalSaved() {
   await loadData()
 }
 
@@ -167,12 +220,19 @@ onMounted(loadData)
               Total de aportes aprobados.
             </p>
           </div>
-          <div class="flex shrink-0 gap-2">
+          <div class="flex shrink-0 flex-wrap justify-end gap-2">
             <button
               class="rounded-lg bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-gray-900 transition"
               @click="showModal = true"
             >
               + Registrar Aporte
+            </button>
+            <button
+              :disabled="totalSavings <= 0"
+              class="rounded-lg bg-amber-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-amber-500 focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:ring-offset-gray-900 transition disabled:opacity-50 disabled:cursor-not-allowed"
+              @click="showWithdrawalModal = true"
+            >
+              Solicitar Retiro
             </button>
             <NuxtLink
               to="/prestamos/solicitar"
@@ -230,6 +290,97 @@ onMounted(loadData)
           </li>
         </ul>
       </div>
+
+      <!-- Inversiones activas del fondo -->
+      <div
+        v-if="activeInvestments.length > 0"
+        class="mt-4 rounded-2xl border border-blue-500/30 bg-gradient-to-br from-blue-600/10 to-violet-600/10 p-6"
+      >
+        <div class="flex items-center gap-3 mb-4">
+          <div class="h-10 w-10 rounded-xl bg-blue-500/20 flex items-center justify-center">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-blue-300" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M12 7a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0V8.414l-4.293 4.293a1 1 0 01-1.414 0L8 10.414l-4.293 4.293a1 1 0 01-1.414-1.414l5-5a1 1 0 011.414 0L11 10.586 14.586 7H12z" clip-rule="evenodd" />
+            </svg>
+          </div>
+          <div class="flex-1">
+            <p class="text-sm font-semibold text-blue-200">Nuestro dinero trabajando</p>
+            <p class="text-xs text-blue-300/70">
+              Invertido: <span class="font-semibold text-blue-200">{{ formatCOP(totalInvested) }}</span>
+              · Rendimiento acumulado:
+              <span class="font-semibold text-emerald-300">{{ formatCOP(totalAccruedInterest) }}</span>
+            </p>
+          </div>
+        </div>
+
+        <ul class="space-y-2">
+          <li
+            v-for="(inv, i) in activeInvestments"
+            :key="i"
+            class="rounded-lg bg-gray-900/50 px-4 py-3"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <p class="text-sm font-medium text-white truncate">{{ inv.name }}</p>
+                <p class="text-xs text-gray-400 mt-0.5">
+                  Tasa anual: <span class="text-emerald-400 font-medium">{{ inv.annual_interest_rate }}%</span>
+                  · Vence {{ formatDate(inv.end_date) }}
+                </p>
+              </div>
+              <div class="text-right shrink-0">
+                <p class="text-sm font-semibold text-white">{{ formatCOP(inv.invested_amount) }}</p>
+                <p class="text-xs text-emerald-400 mt-0.5">
+                  +{{ formatCOP(accruedInterest(inv)) }}
+                </p>
+              </div>
+            </div>
+            <p class="text-[11px] text-gray-500 mt-2">
+              Proyectado al vencimiento: <span class="text-gray-300 font-medium">{{ formatCOP(projectedInterest(inv)) }}</span>
+            </p>
+          </li>
+        </ul>
+      </div>
+
+      <!-- Historial de Retiros -->
+      <div
+        v-if="allWithdrawals.length > 0"
+        class="mt-4 bg-gray-900 rounded-2xl border border-gray-800 p-6"
+      >
+        <div class="flex items-center justify-between mb-4">
+          <p class="text-sm font-medium text-gray-400 uppercase tracking-wider">
+            Historial de Retiros
+          </p>
+          <button
+            v-if="allWithdrawals.length > 5"
+            class="text-xs text-gray-500 hover:text-gray-300 transition"
+            @click="showWithdrawalsHistory = !showWithdrawalsHistory"
+          >
+            {{ showWithdrawalsHistory ? 'Ver menos' : `Ver todos (${allWithdrawals.length})` }}
+          </button>
+        </div>
+
+        <ul class="space-y-2">
+          <li
+            v-for="(withdrawal, i) in (showWithdrawalsHistory ? allWithdrawals : allWithdrawals.slice(0, 5))"
+            :key="i"
+            class="flex items-center justify-between rounded-lg bg-gray-800/50 px-4 py-3"
+          >
+            <div class="flex items-center gap-3">
+              <span
+                class="px-2 py-0.5 text-xs font-medium rounded-full"
+                :class="statusClasses[withdrawal.status] ?? 'bg-gray-500/20 text-gray-400'"
+              >
+                {{ statusLabel[withdrawal.status] ?? withdrawal.status }}
+              </span>
+              <span class="text-sm text-gray-300">
+                {{ formatDate(withdrawal.created_at.slice(0, 10)) }}
+              </span>
+            </div>
+            <span class="text-sm font-medium text-white">
+              {{ formatCOP(withdrawal.amount) }}
+            </span>
+          </li>
+        </ul>
+      </div>
     </template>
 
     <!-- Modal -->
@@ -237,6 +388,13 @@ onMounted(loadData)
       :visible="showModal"
       @close="showModal = false"
       @saved="onContributionSaved"
+    />
+
+    <WithdrawalModal
+      :visible="showWithdrawalModal"
+      :available-savings="totalSavings"
+      @close="showWithdrawalModal = false"
+      @saved="onWithdrawalSaved"
     />
   </div>
 </template>

--- a/app/pages/estatutos.vue
+++ b/app/pages/estatutos.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+  layout: 'default',
+})
+
+interface Article {
+  id: string
+  title: string
+  summary: string
+  body: string
+}
+
+const articles: Article[] = [
+  {
+    id: 'ingresos',
+    title: 'Artículo I — Ingresos',
+    summary: 'Requisitos y cuotas de admisión y reingreso al fondo.',
+    body:
+      'La admisión de un nuevo miembro al fondo tiene un costo de $70.000 COP, mientras que el reingreso de un miembro previamente retirado tiene un costo de $140.000 COP (el doble). ' +
+      'Los nuevos integrantes a partir del año 2023 están exentos del pago de admisión. ' +
+      'Todo aspirante deberá ser aceptado por la Junta Directiva y firmar conformidad con los presentes estatutos.',
+  },
+  {
+    id: 'ahorros',
+    title: 'Artículo II — Ahorros',
+    summary: 'Cuotas mensuales obligatorias y fechas de pago.',
+    body:
+      'La cuota mínima mensual para menores de edad es de $100.000 COP, y para mayores de edad es de $120.000 COP. ' +
+      'El valor del ahorro se define al ingresar al fondo y no puede modificarse durante todo el año en curso. ' +
+      'El plazo máximo de pago es el día 30 de cada mes, con excepción del mes de diciembre, cuya fecha límite es el día 15.',
+  },
+  {
+    id: 'prestamos',
+    title: 'Artículo III — Préstamos',
+    summary: 'Condiciones, tasas y requisitos de codeudores.',
+    body:
+      'Solo los miembros activos del fondo pueden solicitar préstamos. La tasa de interés mínima es del 2% mensual. ' +
+      'Sin fiador, un miembro puede solicitar hasta $200.000 COP o el equivalente al 80% del valor ahorrado (lo que resulte menor). ' +
+      'Para montos superiores, se requiere un codeudor que sea miembro activo del fondo y cuente con capacidad de ahorro suficiente para respaldar la obligación.',
+  },
+  {
+    id: 'moras',
+    title: 'Artículo IV — Moras y Sanciones',
+    summary: 'Penalidades por incumplimiento y faltas.',
+    body:
+      'El atraso de tres cuotas consecutivas en el ahorro mensual genera la expulsión del fondo. ' +
+      'La mora de dos meses en préstamos activa el descuento automático sobre los ahorros del deudor o, en su defecto, sobre los del codeudor. ' +
+      'Llegar 15 minutos tarde a una citación genera una multa de $10.000 COP. La inasistencia a reuniones genera una multa de $30.000 COP que se descuenta directamente de los ahorros.',
+  },
+  {
+    id: 'utilidades',
+    title: 'Artículo V — Utilidades',
+    summary: 'Reparto anual y causales de pérdida del derecho.',
+    body:
+      'A la primera oportunidad de incumplimiento en la fecha de pago del ahorro mensual, el miembro pierde todo derecho a las utilidades anuales del fondo. ' +
+      'Al finalizar el año, se devuelven los aportes a cada miembro, dejando una base operativa de $300.000 COP en la caja del fondo para el siguiente período.',
+  },
+]
+
+const openId = ref<string | null>('ingresos')
+
+function toggle(id: string) {
+  openId.value = openId.value === id ? null : id
+}
+</script>
+
+<template>
+  <div>
+    <!-- Header -->
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-white">Estatutos</h1>
+      <p class="text-gray-400 mt-1">Normas y reglas que rigen el funcionamiento del fondo.</p>
+    </div>
+
+    <!-- Accordion -->
+    <div class="space-y-3">
+      <div
+        v-for="article in articles"
+        :key="article.id"
+        class="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden transition-all"
+        :class="{ 'ring-1 ring-emerald-500/30': openId === article.id }"
+      >
+        <button
+          type="button"
+          class="w-full flex items-center justify-between px-6 py-5 text-left hover:bg-gray-800/30 transition"
+          @click="toggle(article.id)"
+        >
+          <div class="flex-1">
+            <h3 class="text-base font-semibold text-white">{{ article.title }}</h3>
+            <p class="text-xs text-gray-400 mt-0.5">{{ article.summary }}</p>
+          </div>
+          <svg
+            class="w-5 h-5 text-gray-500 shrink-0 ml-4 transition-transform"
+            :class="{ 'rotate-180': openId === article.id }"
+            fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+          </svg>
+        </button>
+
+        <Transition
+          enter-active-class="transition duration-200 ease-out"
+          enter-from-class="opacity-0 -translate-y-1"
+          enter-to-class="opacity-100 translate-y-0"
+          leave-active-class="transition duration-150 ease-in"
+          leave-from-class="opacity-100 translate-y-0"
+          leave-to-class="opacity-0 -translate-y-1"
+        >
+          <div v-if="openId === article.id" class="px-6 pb-6 border-t border-gray-800">
+            <p class="text-sm text-gray-300 leading-relaxed pt-4">{{ article.body }}</p>
+          </div>
+        </Transition>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/pages/junta.vue
+++ b/app/pages/junta.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+  layout: 'default',
+})
+
+interface JuntaMember {
+  role_title: string | null
+  profiles: {
+    id: string
+    full_name: string
+    role: string
+  }
+}
+
+interface JuntaTeam {
+  id: string
+  name: string
+  term: string
+  created_at: string
+  team_members: JuntaMember[]
+}
+
+const supabase = useSupabase()
+const teams = ref<JuntaTeam[]>([])
+const loading = ref(true)
+
+async function loadTeams() {
+  const { data } = await supabase
+    .from('teams')
+    .select('id, name, term, created_at, team_members(role_title, profiles(id, full_name, role))')
+    .ilike('name', '%junta%')
+    .order('created_at', { ascending: false })
+
+  teams.value = (data as unknown as JuntaTeam[]) ?? []
+  loading.value = false
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .slice(0, 2)
+    .map(w => w[0])
+    .join('')
+    .toUpperCase()
+}
+
+function sortedMembers(members: JuntaMember[]): JuntaMember[] {
+  const order = ['presidente', 'vicepresidente', 'tesorero', 'secretario', 'fiscal', 'vocal']
+  return [...members].sort((a, b) => {
+    const ai = order.indexOf((a.role_title ?? '').toLowerCase())
+    const bi = order.indexOf((b.role_title ?? '').toLowerCase())
+    const aVal = ai === -1 ? 999 : ai
+    const bVal = bi === -1 ? 999 : bi
+    return aVal - bVal
+  })
+}
+
+onMounted(loadTeams)
+</script>
+
+<template>
+  <div>
+    <!-- Header -->
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-white">Junta Directiva</h1>
+      <p class="text-gray-400 mt-1">Miembros que lideran y representan al fondo.</p>
+    </div>
+
+    <!-- Skeleton -->
+    <div v-if="loading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div v-for="i in 3" :key="i" class="animate-pulse bg-gray-900 rounded-2xl h-48 border border-gray-800" />
+    </div>
+
+    <!-- Empty -->
+    <div
+      v-else-if="teams.length === 0"
+      class="bg-gray-900 rounded-2xl border border-gray-800 p-12 text-center"
+    >
+      <p class="text-gray-400">No hay juntas directivas registradas.</p>
+      <p class="text-xs text-gray-500 mt-1">Crea un comité con la palabra "Junta" desde el panel de administración.</p>
+    </div>
+
+    <!-- Teams -->
+    <div v-else class="space-y-10">
+      <section v-for="team in teams" :key="team.id">
+        <div class="flex items-center justify-between mb-4">
+          <div>
+            <h2 class="text-lg font-semibold text-white">{{ team.name }}</h2>
+            <p class="text-xs text-gray-500">Período {{ team.term }}</p>
+          </div>
+          <span class="px-2.5 py-1 text-xs font-medium rounded-full bg-emerald-500/20 text-emerald-400 ring-1 ring-emerald-500/30">
+            {{ team.team_members.length }} miembros
+          </span>
+        </div>
+
+        <div v-if="team.team_members.length === 0" class="bg-gray-900 rounded-2xl border border-gray-800 p-8 text-center">
+          <p class="text-sm text-gray-400">Esta junta aún no tiene miembros asignados.</p>
+        </div>
+
+        <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div
+            v-for="member in sortedMembers(team.team_members)"
+            :key="member.profiles.id"
+            class="group relative bg-gray-900 rounded-2xl border border-gray-800 p-6 hover:border-emerald-500/40 transition-all"
+          >
+            <!-- Avatar -->
+            <div class="flex flex-col items-center text-center">
+              <div
+                class="w-20 h-20 rounded-full flex items-center justify-center text-2xl font-bold mb-4 ring-2 ring-offset-4 ring-offset-gray-900"
+                :class="member.profiles.role === 'admin'
+                  ? 'bg-gradient-to-br from-emerald-500/30 to-emerald-600/10 text-emerald-300 ring-emerald-500/40'
+                  : 'bg-gradient-to-br from-blue-500/30 to-blue-600/10 text-blue-300 ring-blue-500/40'"
+              >
+                {{ getInitials(member.profiles.full_name) }}
+              </div>
+
+              <h3 class="text-base font-semibold text-white">{{ member.profiles.full_name }}</h3>
+
+              <p
+                v-if="member.role_title"
+                class="mt-1 text-sm font-medium text-emerald-400"
+              >
+                {{ member.role_title }}
+              </p>
+              <p v-else class="mt-1 text-xs text-gray-500 italic">Sin cargo asignado</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>

--- a/app/pages/prestamos/index.vue
+++ b/app/pages/prestamos/index.vue
@@ -49,7 +49,7 @@ async function loadLoans() {
     .in('status', ['active', 'pending', 'paid'])
     .order('created_at', { ascending: false })
 
-  loans.value = (data as LoanWithPayments[]) ?? []
+  loans.value = (data as unknown as LoanWithPayments[]) ?? []
   loading.value = false
 }
 

--- a/supabase/migrations/20260415000000_add_withdrawals.sql
+++ b/supabase/migrations/20260415000000_add_withdrawals.sql
@@ -1,0 +1,11 @@
+-- ============================================================
+-- FODAF — Migración: tabla withdrawals (retiros de ahorros)
+-- ============================================================
+
+create table withdrawals (
+  id uuid default gen_random_uuid() primary key,
+  profile_id uuid references profiles(id) not null,
+  amount numeric not null check (amount > 0),
+  status text not null check (status in ('pending', 'approved', 'rejected')) default 'pending',
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);

--- a/supabase/migrations/20260415010000_add_investments.sql
+++ b/supabase/migrations/20260415010000_add_investments.sql
@@ -1,0 +1,14 @@
+-- ============================================================
+-- FODAF — Migración: tabla investments (inversiones externas como CDT)
+-- ============================================================
+
+create table investments (
+  id uuid default gen_random_uuid() primary key,
+  name text not null,
+  invested_amount numeric not null check (invested_amount > 0),
+  annual_interest_rate numeric not null,
+  start_date date not null,
+  end_date date not null,
+  status text not null check (status in ('active', 'completed')) default 'active',
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);

--- a/supabase/migrations/20260415020000_add_investment_actual_return.sql
+++ b/supabase/migrations/20260415020000_add_investment_actual_return.sql
@@ -1,0 +1,6 @@
+-- ============================================================
+-- FODAF — Migración: rendimiento real obtenido en inversiones
+-- ============================================================
+
+alter table investments
+  add column actual_return numeric check (actual_return >= 0);

--- a/supabase/migrations/20260415030000_add_role_to_team_members.sql
+++ b/supabase/migrations/20260415030000_add_role_to_team_members.sql
@@ -1,0 +1,5 @@
+-- Agrega el cargo (role_title) de cada integrante dentro de un comité / junta.
+-- Ejemplos: 'Presidente', 'Tesorero', 'Secretario', 'Vocal'.
+
+alter table team_members
+  add column role_title text;

--- a/supabase/migrations/20260415040000_enable_rls_admin_only_mutations.sql
+++ b/supabase/migrations/20260415040000_enable_rls_admin_only_mutations.sql
@@ -1,0 +1,194 @@
+-- ============================================================
+-- FODAF — RLS: solo admin puede UPDATE/DELETE en todas las tablas
+-- ============================================================
+-- Todos los miembros autenticados pueden SELECT e INSERT
+-- (para mantener los flujos existentes: registrar aportes,
+-- solicitar préstamos y retiros, registrar pagos, etc.)
+-- Solo los usuarios con role='admin' pueden UPDATE o DELETE.
+-- ============================================================
+
+-- Helper: detecta si el usuario autenticado es admin.
+create or replace function public.is_admin()
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1 from profiles
+    where id = auth.uid() and role = 'admin'
+  );
+$$;
+
+-- RPC que mantiene el flujo de "pago de préstamo completo" desde el cliente.
+-- LoanPaymentModal llama a esta función en lugar de hacer update directo.
+create or replace function public.mark_loan_paid_if_complete(p_loan_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_requested numeric;
+  v_interest numeric;
+  v_total_due numeric;
+  v_total_paid numeric;
+begin
+  select requested_amount, interest_rate
+  into v_requested, v_interest
+  from loans
+  where id = p_loan_id;
+
+  if v_requested is null then
+    return;
+  end if;
+
+  v_total_due := round(v_requested * (1 + v_interest / 100));
+
+  select coalesce(sum(amount), 0)
+  into v_total_paid
+  from loan_payments
+  where loan_id = p_loan_id;
+
+  if v_total_paid >= v_total_due then
+    update loans
+    set status = 'paid'
+    where id = p_loan_id;
+  end if;
+end;
+$$;
+
+grant execute on function public.mark_loan_paid_if_complete(uuid) to authenticated;
+
+-- ------------------------------------------------------------
+-- Habilitar RLS en todas las tablas
+-- ------------------------------------------------------------
+alter table profiles       enable row level security;
+alter table contributions  enable row level security;
+alter table loans          enable row level security;
+alter table loan_payments  enable row level security;
+alter table teams          enable row level security;
+alter table team_members   enable row level security;
+alter table activities     enable row level security;
+alter table meetings       enable row level security;
+alter table penalties      enable row level security;
+alter table withdrawals    enable row level security;
+alter table investments    enable row level security;
+
+-- ------------------------------------------------------------
+-- Policies por tabla
+-- SELECT: cualquier autenticado
+-- INSERT: cualquier autenticado (los flujos existentes lo requieren)
+-- UPDATE/DELETE: solo admin
+-- ------------------------------------------------------------
+
+-- profiles
+create policy "profiles_select_auth" on profiles
+  for select to authenticated using (true);
+create policy "profiles_insert_auth" on profiles
+  for insert to authenticated with check (true);
+create policy "profiles_update_admin" on profiles
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "profiles_delete_admin" on profiles
+  for delete to authenticated using (public.is_admin());
+
+-- contributions
+create policy "contributions_select_auth" on contributions
+  for select to authenticated using (true);
+create policy "contributions_insert_auth" on contributions
+  for insert to authenticated with check (true);
+create policy "contributions_update_admin" on contributions
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "contributions_delete_admin" on contributions
+  for delete to authenticated using (public.is_admin());
+
+-- loans
+create policy "loans_select_auth" on loans
+  for select to authenticated using (true);
+create policy "loans_insert_auth" on loans
+  for insert to authenticated with check (true);
+create policy "loans_update_admin" on loans
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "loans_delete_admin" on loans
+  for delete to authenticated using (public.is_admin());
+
+-- loan_payments
+create policy "loan_payments_select_auth" on loan_payments
+  for select to authenticated using (true);
+create policy "loan_payments_insert_auth" on loan_payments
+  for insert to authenticated with check (true);
+create policy "loan_payments_update_admin" on loan_payments
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "loan_payments_delete_admin" on loan_payments
+  for delete to authenticated using (public.is_admin());
+
+-- teams
+create policy "teams_select_auth" on teams
+  for select to authenticated using (true);
+create policy "teams_insert_auth" on teams
+  for insert to authenticated with check (true);
+create policy "teams_update_admin" on teams
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "teams_delete_admin" on teams
+  for delete to authenticated using (public.is_admin());
+
+-- team_members
+create policy "team_members_select_auth" on team_members
+  for select to authenticated using (true);
+create policy "team_members_insert_auth" on team_members
+  for insert to authenticated with check (true);
+create policy "team_members_update_admin" on team_members
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "team_members_delete_admin" on team_members
+  for delete to authenticated using (public.is_admin());
+
+-- activities
+create policy "activities_select_auth" on activities
+  for select to authenticated using (true);
+create policy "activities_insert_auth" on activities
+  for insert to authenticated with check (true);
+create policy "activities_update_admin" on activities
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "activities_delete_admin" on activities
+  for delete to authenticated using (public.is_admin());
+
+-- meetings
+create policy "meetings_select_auth" on meetings
+  for select to authenticated using (true);
+create policy "meetings_insert_auth" on meetings
+  for insert to authenticated with check (true);
+create policy "meetings_update_admin" on meetings
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "meetings_delete_admin" on meetings
+  for delete to authenticated using (public.is_admin());
+
+-- penalties
+create policy "penalties_select_auth" on penalties
+  for select to authenticated using (true);
+create policy "penalties_insert_auth" on penalties
+  for insert to authenticated with check (true);
+create policy "penalties_update_admin" on penalties
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "penalties_delete_admin" on penalties
+  for delete to authenticated using (public.is_admin());
+
+-- withdrawals
+create policy "withdrawals_select_auth" on withdrawals
+  for select to authenticated using (true);
+create policy "withdrawals_insert_auth" on withdrawals
+  for insert to authenticated with check (true);
+create policy "withdrawals_update_admin" on withdrawals
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "withdrawals_delete_admin" on withdrawals
+  for delete to authenticated using (public.is_admin());
+
+-- investments
+create policy "investments_select_auth" on investments
+  for select to authenticated using (true);
+create policy "investments_insert_auth" on investments
+  for insert to authenticated with check (true);
+create policy "investments_update_admin" on investments
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "investments_delete_admin" on investments
+  for delete to authenticated using (public.is_admin());

--- a/types/database.ts
+++ b/types/database.ts
@@ -9,6 +9,8 @@ export type ContributionStatus = 'pending' | 'approved' | 'rejected'
 export type LoanStatus = 'pending' | 'active' | 'paid' | 'defaulted' | 'rejected'
 export type PenaltyReason = 'absence' | 'late_arrival' | 'other'
 export type PenaltyStatus = 'pending' | 'paid' | 'deducted_from_savings'
+export type WithdrawalStatus = 'pending' | 'approved' | 'rejected'
+export type InvestmentStatus = 'active' | 'completed'
 
 // ---- Tables ----
 
@@ -58,6 +60,7 @@ export interface Team {
 export interface TeamMember {
   team_id: string
   profile_id: string
+  role_title: string | null
 }
 
 export interface Activity {
@@ -87,6 +90,26 @@ export interface Penalty {
   created_at: string
 }
 
+export interface Withdrawal {
+  id: string
+  profile_id: string
+  amount: number
+  status: WithdrawalStatus
+  created_at: string
+}
+
+export interface Investment {
+  id: string
+  name: string
+  invested_amount: number
+  annual_interest_rate: number
+  start_date: string
+  end_date: string
+  status: InvestmentStatus
+  actual_return: number | null
+  created_at: string
+}
+
 // ---- Database schema map (útil para tipado genérico) ----
 
 export interface Database {
@@ -99,4 +122,6 @@ export interface Database {
   activities: Activity
   meetings: Meeting
   penalties: Penalty
+  withdrawals: Withdrawal
+  investments: Investment
 }


### PR DESCRIPTION
## Summary

This PR consolidates several related improvements that turn FODAF into a fully manageable admin application:

- **Withdrawals**: members can request withdrawals against their savings, admins approve/reject.
- **Investments (CDT)**: track external instruments with projected and actual returns; integrated into dashboard and global balance.
- **Estatutos & Junta Directiva**: public informational pages. Team members can now carry a `role_title` (Presidente, Tesorero, etc.).
- **Row Level Security**: RLS is now enabled on every table. Only admins can `UPDATE` or `DELETE`; `SELECT`/`INSERT` remain open to authenticated users so existing member flows keep working. A `SECURITY DEFINER` RPC preserves the "mark loan as paid" transition from the member side.
- **Full admin edit/delete**: every admin view now lists every record (with filters), ships full-field edit modals and delete confirmation. A new `admin/miembros.vue` manages profiles and can create new members (via `signUp` + session restore) without logging the admin out.
- **Sidebar navigation**: the top nav was cramped with 11 items; replaced with a grouped fixed sidebar (Principal / Fondo / Administración) and a slim topbar.

## Database migrations

Four new migrations, meant to be applied in order:

1. `20260415000000_add_withdrawals.sql`
2. `20260415010000_add_investments.sql` (+ `..020000_add_investment_actual_return.sql`)
3. `20260415030000_add_role_to_team_members.sql`
4. `20260415040000_enable_rls_admin_only_mutations.sql`