### PR TITLE
feat: 2026 statutes, configurable fund parameters and activities POS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Tablas en PostgreSQL (Supabase), relacionadas mediante UUIDs:
 - `penalties` — (id, profile_id, meeting_id, reason, amount, status, created_at). Reason: `absence`, `late_arrival`, `other`. Status: `pending`, `paid`, `deducted_from_savings`.
 - `withdrawals` — (id, profile_id, amount, status, created_at). Status: `pending`, `approved`, `rejected`. Representa solicitudes de retiro de ahorros.
 - `investments` — (id, name, invested_amount, annual_interest_rate, start_date, end_date, status, actual_return, created_at). Status: `active`, `completed`. `actual_return` se llena cuando se finaliza la inversión y representa el rendimiento real obtenido (entra al Capital en Caja).
-- `fund_settings` — (year [PK], admission_fee, reentry_multiplier, enrollment_deadline_day, admission_exemption_year, legacy_member_cutoff_year, min_savings_minor, min_savings_adult, payment_deadline_day_january, payment_deadline_day_regular, missed_installments_for_expulsion, loan_default_months_for_deduction, penalty_absence, penalty_late_arrival, min_interest_rate, loan_limit_without_guarantor, loan_savings_percentage_cap, year_end_base, board_min_seniority_years, created_at, updated_at). Parámetros configurables del fondo, **una fila por año**. Se leen con el composable `useFundSettings()` y se editan desde `/admin/parametros`.
+- `fund_settings` — (year [PK], min_savings_minor, min_savings_adult, penalty_absence, penalty_late_arrival, min_interest_rate, loan_limit_without_guarantor, loan_savings_percentage_cap, year_end_base, created_at, updated_at). Parámetros configurables del fondo, **una fila por año**. Se leen con el composable `useFundSettings()` y se editan desde `/admin/parametros`. Solo contiene los parámetros que el código consume; las reglas de estatutos sin lógica implementada no se parametrizan.
 
 ## Parámetros Configurables del Fondo
 Los valores que cambian de año a año (cuotas, bases, límites, multas) **NO se hardcodean**. Viven en la tabla `fund_settings`, con **una fila por año** (`year` como PK).
@@ -78,14 +78,14 @@ Los valores que cambian de año a año (cuotas, bases, límites, multas) **NO se
 - Al agregar un parámetro nuevo: columna en una migración nueva, campo en la interfaz `FundSettings` (`types/database.ts`), y campo en `fieldGroups` de `/admin/parametros`.
 
 ## Reglas de Negocio y Estatutos (ESTRICTO)
-Valores vigentes según los **estatutos modificados en enero de 2026**. Son los valores por defecto que viven en `fund_settings` para el año 2026; la app siempre los lee desde ahí (vía `useFundSettings()`), nunca de constantes. El nombre entre paréntesis es la columna correspondiente.
+Valores vigentes según los **estatutos modificados en enero de 2026**. Las reglas anotadas con el nombre de una columna (ej. `min_interest_rate`) son **parametrizables**: viven en `fund_settings` y la app las lee con `useFundSettings()`, nunca de constantes. Las reglas **sin anotación** están documentadas como estatuto pero **no parametrizadas ni enforced en código** (su lógica aún no está implementada).
 
 ### Ingresos
-- Admisión de miembro nuevo: **$80.000 COP** (`admission_fee`).
-- Reingreso: **el doble** de la admisión (`reentry_multiplier` = 2 → $160.000 COP).
-- Plazo máximo para ingresar al fondo: **31 de enero** (`enrollment_deadline_day`).
-- Excepción: nuevos integrantes a partir de 2023 están exentos del pago de admisión (`admission_exemption_year`).
-- "Asociados antiguos" se definen por el año de corte 2022 (`legacy_member_cutoff_year`).
+- Admisión de miembro nuevo: **$80.000 COP**.
+- Reingreso: **el doble** de la admisión ($160.000 COP).
+- Plazo máximo para ingresar al fondo: **31 de enero**.
+- Excepción: nuevos integrantes a partir de 2023 están exentos del pago de admisión.
+- "Asociados antiguos" se definen por el año de corte 2022.
 
 ### Ahorros
 - Cuota mínima mensual para **menores**: **$100.000 COP** (`min_savings_minor`).
@@ -93,8 +93,8 @@ Valores vigentes según los **estatutos modificados en enero de 2026**. Son los 
 - El valor del ahorro se define con el primer pago y **no se puede modificar durante el año en curso**.
 
 ### Fechas de Pago
-- Cuota de **enero**: plazo máximo **día 30** (`payment_deadline_day_january`).
-- Cuota de **febrero a noviembre**: plazo máximo **día 15** (`payment_deadline_day_regular`).
+- Cuota de **enero**: plazo máximo **día 30**.
+- Cuota de **febrero a noviembre**: plazo máximo **día 15**.
 - **Diciembre**: flexible según la fecha de la reunión de fin de año.
 
 ### Préstamos
@@ -104,8 +104,8 @@ Valores vigentes según los **estatutos modificados en enero de 2026**. Son los 
 - Para montos superiores: se requiere un **codeudor** que sea miembro del fondo con capacidad suficiente.
 
 ### Moras y Sanciones
-- **Atraso de 3 cuotas de ahorro** (`missed_installments_for_expulsion`) → Expulsión del fondo. Durante el primer mes de atraso hay derecho, por única vez, a renegociación (primero con el Comité, luego con la Junta).
-- **Mora de 2 meses en préstamos** (`loan_default_months_for_deduction`) → Descuento automático de sus ahorros o los de su codeudor.
+- **Atraso de 3 cuotas de ahorro** → Expulsión del fondo. Durante el primer mes de atraso hay derecho, por única vez, a renegociación (primero con el Comité, luego con la Junta).
+- **Mora de 2 meses en préstamos** → Descuento automático de sus ahorros o los de su codeudor.
 - **Llegar 15 minutos tarde** a citaciones → Multa de **$10.000 COP** (`penalty_late_arrival`).
 - **Inasistencia a reuniones** → Multa de **$30.000 COP** (`penalty_absence`), descontada de los ahorros.
 
@@ -114,4 +114,4 @@ Valores vigentes según los **estatutos modificados en enero de 2026**. Son los 
 - Al final del año se devuelven los aportes dejando una **base de $350.000 COP** en el fondo (`year_end_base`).
 
 ### Junta Directiva
-- Se elige entre miembros con **3 años o más de antigüedad** (`board_min_seniority_years`). *(Parámetro disponible en `fund_settings`; aún no implementado en código.)*
+- Se elige entre miembros con **3 años o más de antigüedad**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Sistema financiero cerrado para gestionar los ahorros, préstamos, eventos y mul
 - Composables para lógica reutilizable (`app/composables/`).
 - Separación de responsabilidades: componentes presentacionales vs lógica de negocio.
 - Archivos de tipos en `types/`.
+- **Parámetros del fondo:** los valores de negocio (cuotas, límites, multas, bases) **no se hardcodean**; se leen de la tabla `fund_settings` con el composable `useFundSettings()`. Ver sección "Parámetros Configurables del Fondo".
 - Variables de entorno en `.env` (nunca se commitean).
 - Migraciones SQL en `supabase/migrations/`.
 - Datos de prueba en `supabase/seed.sql`.
@@ -67,35 +68,50 @@ Tablas en PostgreSQL (Supabase), relacionadas mediante UUIDs:
 - `penalties` — (id, profile_id, meeting_id, reason, amount, status, created_at). Reason: `absence`, `late_arrival`, `other`. Status: `pending`, `paid`, `deducted_from_savings`.
 - `withdrawals` — (id, profile_id, amount, status, created_at). Status: `pending`, `approved`, `rejected`. Representa solicitudes de retiro de ahorros.
 - `investments` — (id, name, invested_amount, annual_interest_rate, start_date, end_date, status, actual_return, created_at). Status: `active`, `completed`. `actual_return` se llena cuando se finaliza la inversión y representa el rendimiento real obtenido (entra al Capital en Caja).
+- `fund_settings` — (year [PK], admission_fee, reentry_multiplier, enrollment_deadline_day, admission_exemption_year, legacy_member_cutoff_year, min_savings_minor, min_savings_adult, payment_deadline_day_january, payment_deadline_day_regular, missed_installments_for_expulsion, loan_default_months_for_deduction, penalty_absence, penalty_late_arrival, min_interest_rate, loan_limit_without_guarantor, loan_savings_percentage_cap, year_end_base, board_min_seniority_years, created_at, updated_at). Parámetros configurables del fondo, **una fila por año**. Se leen con el composable `useFundSettings()` y se editan desde `/admin/parametros`.
+
+## Parámetros Configurables del Fondo
+Los valores que cambian de año a año (cuotas, bases, límites, multas) **NO se hardcodean**. Viven en la tabla `fund_settings`, con **una fila por año** (`year` como PK).
+- Leerlos **siempre** con el composable **`useFundSettings(year?)`** (`app/composables/useFundSettings.ts`) — año actual por defecto, con fallback al año configurado más reciente. La carga se cachea por año en estado global.
+- El admin los edita desde la página **`/admin/parametros`** (selector de año + formulario por secciones).
+- **Histórico por año:** una liquidación de un año pasado se calcula con los parámetros de ese año, no con los vigentes.
+- Al agregar un parámetro nuevo: columna en una migración nueva, campo en la interfaz `FundSettings` (`types/database.ts`), y campo en `fieldGroups` de `/admin/parametros`.
 
 ## Reglas de Negocio y Estatutos (ESTRICTO)
+Valores vigentes según los **estatutos modificados en enero de 2026**. Son los valores por defecto que viven en `fund_settings` para el año 2026; la app siempre los lee desde ahí (vía `useFundSettings()`), nunca de constantes. El nombre entre paréntesis es la columna correspondiente.
 
 ### Ingresos
-- Admisión de miembro nuevo: **$70.000 COP**.
-- Reingreso: **$140.000 COP** (el doble).
-- Excepción: nuevos integrantes a partir de 2023 están exentos de pago de admisión.
+- Admisión de miembro nuevo: **$80.000 COP** (`admission_fee`).
+- Reingreso: **el doble** de la admisión (`reentry_multiplier` = 2 → $160.000 COP).
+- Plazo máximo para ingresar al fondo: **31 de enero** (`enrollment_deadline_day`).
+- Excepción: nuevos integrantes a partir de 2023 están exentos del pago de admisión (`admission_exemption_year`).
+- "Asociados antiguos" se definen por el año de corte 2022 (`legacy_member_cutoff_year`).
 
 ### Ahorros
-- Cuota mínima mensual para **menores**: **$100.000 COP**.
-- Cuota mínima mensual para **mayores**: **$120.000 COP**.
-- El valor del ahorro se define al ingresar al fondo y **no se puede modificar durante todo el año**.
+- Cuota mínima mensual para **menores**: **$100.000 COP** (`min_savings_minor`).
+- Cuota mínima mensual para **mayores**: **$120.000 COP** (`min_savings_adult`).
+- El valor del ahorro se define con el primer pago y **no se puede modificar durante el año en curso**.
 
 ### Fechas de Pago
-- Plazo máximo para la cuota mensual: **día 30 de cada mes**.
-- Excepción diciembre: plazo máximo es el **día 15**.
+- Cuota de **enero**: plazo máximo **día 30** (`payment_deadline_day_january`).
+- Cuota de **febrero a noviembre**: plazo máximo **día 15** (`payment_deadline_day_regular`).
+- **Diciembre**: flexible según la fecha de la reunión de fin de año.
 
 ### Préstamos
 - Solo se presta a **miembros activos** del fondo.
-- Interés mínimo: **2%**.
-- Sin fiador: hasta **$200.000 COP** o el **80% del valor ahorrado** (el menor).
+- Interés mínimo: **2%** (`min_interest_rate`).
+- Sin fiador: hasta **$500.000 COP** (`loan_limit_without_guarantor`) o el **80% del valor ahorrado** (`loan_savings_percentage_cap`) — el menor.
 - Para montos superiores: se requiere un **codeudor** que sea miembro del fondo con capacidad suficiente.
 
 ### Moras y Sanciones
-- **Atraso de 3 cuotas de ahorro** → Expulsión del fondo.
-- **Mora de 2 meses en préstamos** → Descuento automático de sus ahorros o los de su codeudor.
-- **Llegar 15 minutos tarde** a citaciones → Multa de **$10.000 COP**.
-- **Inasistencia a reuniones** → Multa de **$30.000 COP** (descontado de los ahorros).
+- **Atraso de 3 cuotas de ahorro** (`missed_installments_for_expulsion`) → Expulsión del fondo. Durante el primer mes de atraso hay derecho, por única vez, a renegociación (primero con el Comité, luego con la Junta).
+- **Mora de 2 meses en préstamos** (`loan_default_months_for_deduction`) → Descuento automático de sus ahorros o los de su codeudor.
+- **Llegar 15 minutos tarde** a citaciones → Multa de **$10.000 COP** (`penalty_late_arrival`).
+- **Inasistencia a reuniones** → Multa de **$30.000 COP** (`penalty_absence`), descontada de los ahorros.
 
-### Utilidades
+### Utilidades y Cierre Anual
 - A la **primera oportunidad de incumplimiento** en la fecha de pago del ahorro mensual, el miembro **pierde todo derecho a las utilidades anuales**.
-- Al final del año se devuelven los aportes dejando una **base de $300.000 COP** en el fondo.
+- Al final del año se devuelven los aportes dejando una **base de $350.000 COP** en el fondo (`year_end_base`).
+
+### Junta Directiva
+- Se elige entre miembros con **3 años o más de antigüedad** (`board_min_seniority_years`). *(Parámetro disponible en `fund_settings`; aún no implementado en código.)*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,10 @@ Tablas en PostgreSQL (Supabase), relacionadas mediante UUIDs:
 - `loan_payments` — (id, loan_id, amount, payment_date, created_at).
 - `teams` — (id, name, term, created_at).
 - `team_members` — (team_id, profile_id, role_title). PK compuesta. `role_title` es opcional y representa el cargo dentro del equipo (ej. "Presidente", "Tesorero", "Secretario").
-- `activities` — (id, team_id, name, activity_date, costs, net_profits, created_at).
+- `activities` — (id, team_id, name, activity_date, start_at, status, finished_at, created_at). Los totales financieros (costos, ingresos, ganancia) **no se almacenan**: se derivan en tiempo real de `activity_expenses`, `activity_products` y `activity_sales`. `status`: `scheduled` | `in_progress` | `finished`. `start_at`: fecha y hora de inicio (timestamptz); obligatorio en actividades nuevas, nullable solo por compatibilidad con filas previas a la migración. `finished_at`: se llena cuando alguien finaliza la actividad.
+- `activity_expenses` — (id, activity_id, description, amount, created_at). Gastos generales de una actividad (ej. alquiler de sillas).
+- `activity_products` — (id, activity_id, name, cost_price, selling_price, stock_quantity, created_at). Inventario de productos de una actividad para el POS. `stock_quantity` es la cantidad física comprada/disponible; el admin puede ajustarla durante el evento.
+- `activity_sales` — (id, activity_id, seller_id, buyer_name, product_id, quantity, total_price, created_at). Ventas registradas desde el POS por los miembros. `total_price` lo calcula un trigger (`quantity * selling_price` del producto). El **stock disponible** de un producto = `stock_quantity` menos la suma de `quantity` vendida en `activity_sales`.
 - `meetings` — (id, topic, meeting_date, created_at).
 - `penalties` — (id, profile_id, meeting_id, reason, amount, status, created_at). Reason: `absence`, `late_arrival`, `other`. Status: `pending`, `paid`, `deducted_from_savings`.
 - `withdrawals` — (id, profile_id, amount, status, created_at). Status: `pending`, `approved`, `rejected`. Representa solicitudes de retiro de ahorros.
@@ -115,3 +118,29 @@ Valores vigentes según los **estatutos modificados en enero de 2026**. Las regl
 
 ### Junta Directiva
 - Se elige entre miembros con **3 años o más de antigüedad**.
+
+### Actividades y Eventos (POS)
+- Módulo unificado en `/actividades` (lista) y `/actividades/[id]` (detalle). **No existe** un módulo separado `/admin/actividades`: el mismo detalle es el panel admin y el POS, con UI condicional por permisos.
+- Cada actividad tiene gastos generales (`activity_expenses`), inventario (`activity_products`) y ventas (`activity_sales`).
+- Una venta se registra desde el botón **"+ Nueva Venta"** del detalle (modal `ActivitySaleModal`).
+- **Validación de stock (ESTRICTO):** no se puede vender más cantidad que el stock disponible (`stock_quantity` − cantidad ya vendida). El modal bloquea el envío y muestra un toast de error.
+- **Matemática del evento** (derivada, en tiempo real):
+  - **Costos Totales** = Σ `amount` de gastos + Σ (`cost_price` × `stock_quantity`) de productos (lo comprado ya se gastó).
+  - **Ingresos Brutos** = Σ `total_price` de ventas.
+  - **Ganancia Neta** = Ingresos Brutos − Costos Totales.
+
+#### Ciclo de vida y permisos por comité
+Estados: **`scheduled`** → **`in_progress`** → **`finished`**.
+- Una actividad se crea con `start_at` obligatorio. El cliente decide el estado inicial: `scheduled` si `start_at > now()`, `in_progress` si ya pasó.
+- La transición `scheduled → in_progress` es **automática por hora**: la función SQL **`effective_activity_status(status, start_at)`** rebaja una `scheduled` cuya hora ya pasó al estado efectivo `in_progress`. No hay cron — el cálculo es "on-read" tanto en BD (RLS) como en cliente (composable). El composable mantiene un `useGlobalClock()` que tickea cada 30s para que los badges cambien en vivo.
+- **Cierre:** RPC **`finish_activity(p_activity_id)`** (cualquier miembro del comité asignado o admin). Acepta cerrar tanto `scheduled` como `in_progress` (cancelación incluida).
+- **Reapertura:** RPC **`reopen_activity(p_activity_id)`** (solo admin). El estado destino depende de `start_at`: si la hora aún no llega → `scheduled`; si ya pasó → `in_progress`.
+
+Permisos por estado **efectivo**:
+- **`scheduled` (futuro)**: admin y comité ven el detalle, pueden editar gastos e inventario (preparación). Las ventas (POS) están deshabilitadas en cliente hasta cruzar la hora — `canSell = canEdit && effectiveStatus === 'in_progress'`. El resto de miembros ve la actividad en la lista con badge **"Programada"** pero no accede al detalle.
+- **`in_progress`** (incluido `scheduled` cuya hora ya llegó): admin y comité editan todo incluidas ventas. El resto sigue sin acceso al detalle.
+- **`finished`**: todos los miembros ven el detalle en **modo solo lectura**. Nadie puede modificar gastos, inventario ni ventas hasta que un admin la reabra.
+
+Implementación:
+- **Cliente:** composable **`useActivityPermissions()`** (`effectiveStatus`, `canViewDetail`, `canEdit`, `canFinalize`, `canReopen`). Se basa en `team_members` del comité, el rol del usuario, `start_at` y el reloj global.
+- **Servidor (RLS):** las policies de `activity_expenses`, `activity_products` y `activity_sales` delegan en **`is_activity_editable(activity_id)`** (admin o miembro del comité, y `status <> 'finished'`). UPDATE en `activities` sigue siendo admin-only; el cambio de `status` pasa siempre por las RPCs.

--- a/app/components/ActivitySaleModal.vue
+++ b/app/components/ActivitySaleModal.vue
@@ -1,0 +1,355 @@
+<script setup lang="ts">
+interface ProductOption {
+  id: string
+  name: string
+  selling_price: number
+  /** Stock disponible: `stock_quantity` − unidades ya vendidas. */
+  available: number
+}
+
+interface MemberOption {
+  id: string
+  full_name: string
+}
+
+/** Venta en modo edición. Si está presente, el modal pre-llena
+ *  los campos y al guardar hace UPDATE en lugar de INSERT. */
+export interface EditingSale {
+  id: string
+  product_id: string
+  quantity: number
+  buyer_id: string | null
+  buyer_name: string | null
+}
+
+const props = defineProps<{
+  visible: boolean
+  activityId: string
+  products: ProductOption[]
+  /** Miembros del fondo para el selector de comprador. */
+  members: MemberOption[]
+  /** Si se pasa, el modal entra en modo edición. */
+  editingSale?: EditingSale | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+  saved: []
+}>()
+
+const supabase = useSupabase()
+const toast = useToast()
+
+const selectedProductId = ref('')
+const quantity = ref<number | null>(null)
+
+/**
+ * Selección de comprador. Valores posibles:
+ *   - `''`           → "Sin especificar" (ambos campos quedan null).
+ *   - `'__other__'`  → comprador externo (se llena `buyer_name`).
+ *   - UUID de perfil → miembro del fondo (se llena `buyer_id`).
+ */
+const buyerSelection = ref<string>('')
+const externalBuyerName = ref('')
+
+const submitting = ref(false)
+
+const isEditing = computed(() => !!props.editingSale)
+
+// Productos visibles en el select: solo los que tienen stock
+// disponible. En modo edición, el producto de la venta original
+// debe seguir apareciendo aunque su stock haya quedado en 0
+// (porque el usuario podría querer mantener el mismo producto).
+const availableProducts = computed(() =>
+  props.products.filter(p =>
+    p.available > 0 || p.id === props.editingSale?.product_id,
+  ),
+)
+
+const selectedProduct = computed(() =>
+  props.products.find(p => p.id === selectedProductId.value) ?? null,
+)
+
+// Stock disponible considerando el modo edición: si estamos
+// editando una venta y el producto seleccionado es el mismo que
+// el de la venta original, las unidades de esa venta NO deben
+// contar como "ya vendidas" — el usuario las está reasignando.
+const availableStock = computed(() => {
+  if (!selectedProduct.value) return 0
+  const base = selectedProduct.value.available
+  if (props.editingSale && props.editingSale.product_id === selectedProduct.value.id) {
+    return base + props.editingSale.quantity
+  }
+  return base
+})
+
+const exceedsStock = computed(() =>
+  !!quantity.value && !!selectedProduct.value && quantity.value > availableStock.value,
+)
+
+const saleTotal = computed(() => {
+  if (!selectedProduct.value || !quantity.value) return 0
+  return selectedProduct.value.selling_price * quantity.value
+})
+
+function resetForm() {
+  selectedProductId.value = ''
+  quantity.value = null
+  buyerSelection.value = ''
+  externalBuyerName.value = ''
+}
+
+// Pre-llena el formulario cuando entra en modo edición y se abre,
+// o lo limpia cuando se cierra.
+watch(() => props.visible, (open) => {
+  if (!open) {
+    resetForm()
+    return
+  }
+  const sale = props.editingSale
+  if (sale) {
+    selectedProductId.value = sale.product_id
+    quantity.value = sale.quantity
+    if (sale.buyer_id) {
+      buyerSelection.value = sale.buyer_id
+      externalBuyerName.value = ''
+    }
+    else if (sale.buyer_name) {
+      buyerSelection.value = '__other__'
+      externalBuyerName.value = sale.buyer_name
+    }
+    else {
+      buyerSelection.value = ''
+      externalBuyerName.value = ''
+    }
+  }
+})
+
+async function handleSubmit() {
+  if (!selectedProduct.value) return
+  if (!quantity.value || quantity.value <= 0) return
+
+  // REGLA DE NEGOCIO ESTRICTA: no se puede vender más que el stock disponible.
+  if (quantity.value > availableStock.value) {
+    toast.error(
+      `Stock insuficiente. Solo quedan ${availableStock.value} unidades. `
+      + 'Dile al Admin que registre más inventario.',
+    )
+    return
+  }
+
+  submitting.value = true
+
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    submitting.value = false
+    toast.error('Tu sesión expiró. Vuelve a iniciar sesión.')
+    return
+  }
+
+  // Decidir buyer_id / buyer_name según selección. El CHECK
+  // `activity_sales_buyer_one_of` exige que solo uno tenga valor.
+  let buyerId: string | null = null
+  let buyerName: string | null = null
+  if (buyerSelection.value === '__other__') {
+    buyerName = externalBuyerName.value.trim() || null
+  }
+  else if (buyerSelection.value) {
+    buyerId = buyerSelection.value
+  }
+
+  // total_price lo calcula el trigger set_sale_total_price tanto
+  // en INSERT como en UPDATE.
+  let error: { message: string } | null = null
+  if (props.editingSale) {
+    const res = await supabase
+      .from('activity_sales')
+      .update({
+        product_id: selectedProduct.value.id,
+        quantity: quantity.value,
+        buyer_id: buyerId,
+        buyer_name: buyerName,
+      })
+      .eq('id', props.editingSale.id)
+    error = res.error
+  }
+  else {
+    const res = await supabase.from('activity_sales').insert({
+      activity_id: props.activityId,
+      seller_id: user.id,
+      product_id: selectedProduct.value.id,
+      quantity: quantity.value,
+      buyer_id: buyerId,
+      buyer_name: buyerName,
+    })
+    error = res.error
+  }
+
+  submitting.value = false
+
+  if (error) {
+    toast.error(props.editingSale ? 'Error al actualizar la venta.' : 'Error al registrar la venta. Intenta de nuevo.')
+    return
+  }
+
+  toast.success(props.editingSale ? 'Venta actualizada.' : 'Venta registrada correctamente.')
+  emit('saved')
+  emit('close')
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="visible"
+        class="fixed inset-0 z-50 flex items-center justify-center px-4"
+      >
+        <div class="absolute inset-0 bg-black/60" @click="emit('close')" />
+
+        <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+          <div class="flex items-center justify-between mb-6">
+            <h2 class="text-xl font-bold text-white">{{ isEditing ? 'Editar Venta' : 'Nueva Venta' }}</h2>
+            <button class="text-gray-500 hover:text-white transition" @click="emit('close')">
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+              </svg>
+            </button>
+          </div>
+
+          <div v-if="products.length === 0" class="text-center py-6">
+            <p class="text-gray-400">No hay productos en el inventario.</p>
+            <p class="text-sm text-gray-500 mt-1">Agrega productos antes de registrar ventas.</p>
+          </div>
+
+          <div v-else-if="availableProducts.length === 0" class="text-center py-6">
+            <p class="text-gray-400">Todos los productos están agotados.</p>
+            <p class="text-sm text-gray-500 mt-1">Pídele al comité que aumente el stock para seguir vendiendo.</p>
+          </div>
+
+          <form v-else class="space-y-5" @submit.prevent="handleSubmit">
+            <div>
+              <label for="sale-product" class="block text-sm font-medium text-gray-300 mb-1">
+                Producto
+              </label>
+              <select
+                id="sale-product"
+                v-model="selectedProductId"
+                required
+                class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+              >
+                <option value="" disabled>Selecciona un producto</option>
+                <option
+                  v-for="product in availableProducts"
+                  :key="product.id"
+                  :value="product.id"
+                >
+                  {{ product.name }} — {{ formatCOP(product.selling_price) }} ({{ product.available }} disp.)
+                </option>
+              </select>
+            </div>
+
+            <div
+              v-if="selectedProduct"
+              class="rounded-lg px-4 py-3 flex items-center justify-between"
+              :class="availableStock > 0
+                ? 'bg-gray-800/50'
+                : 'bg-red-500/10 border border-red-500/30'"
+            >
+              <span class="text-sm text-gray-400">Stock disponible</span>
+              <span
+                class="text-lg font-bold"
+                :class="availableStock > 0 ? 'text-emerald-400' : 'text-red-400'"
+              >
+                {{ availableStock }} unidades
+              </span>
+            </div>
+
+            <div>
+              <label for="sale-quantity" class="block text-sm font-medium text-gray-300 mb-1">
+                Cantidad
+              </label>
+              <input
+                id="sale-quantity"
+                v-model.number="quantity"
+                type="number"
+                required
+                min="1"
+                placeholder="1"
+                class="w-full rounded-lg border bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:ring-1 outline-none transition"
+                :class="exceedsStock
+                  ? 'border-red-500 focus:border-red-500 focus:ring-red-500'
+                  : 'border-gray-700 focus:border-emerald-500 focus:ring-emerald-500'"
+              />
+              <p v-if="exceedsStock" class="text-xs text-red-400 mt-1">
+                Solo quedan {{ availableStock }} unidades disponibles.
+              </p>
+            </div>
+
+            <div>
+              <label for="sale-buyer" class="block text-sm font-medium text-gray-300 mb-1">
+                Comprador <span class="text-gray-500">(opcional)</span>
+              </label>
+              <select
+                id="sale-buyer"
+                v-model="buyerSelection"
+                class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+              >
+                <option value="">Sin especificar</option>
+                <option
+                  v-for="member in members"
+                  :key="member.id"
+                  :value="member.id"
+                >
+                  {{ member.full_name }}
+                </option>
+                <option value="__other__">Otro (escribir nombre)</option>
+              </select>
+              <input
+                v-if="buyerSelection === '__other__'"
+                v-model="externalBuyerName"
+                type="text"
+                placeholder="Nombre del comprador externo"
+                class="mt-2 w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+              />
+            </div>
+
+            <div
+              v-if="selectedProduct && quantity && quantity > 0"
+              class="rounded-lg bg-gray-800/50 px-4 py-3 flex items-center justify-between"
+            >
+              <span class="text-sm text-gray-400">Total de la venta</span>
+              <span class="text-sm font-semibold text-white">{{ formatCOP(saleTotal) }}</span>
+            </div>
+
+            <div class="flex gap-2 pt-2">
+              <button
+                type="button"
+                class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                @click="emit('close')"
+              >
+                Cancelar
+              </button>
+              <button
+                type="submit"
+                :disabled="submitting || exceedsStock || availableStock <= 0"
+                class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {{ submitting
+                  ? (isEditing ? 'Guardando...' : 'Registrando...')
+                  : (isEditing ? 'Guardar Cambios' : 'Registrar Venta') }}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/app/components/ContributionModal.vue
+++ b/app/components/ContributionModal.vue
@@ -10,6 +10,7 @@ const emit = defineEmits<{
 
 const supabase = useSupabase()
 const toast = useToast()
+const { settings: fundSettings } = useFundSettings()
 
 const amount = ref<number | null>(null)
 const { toLocalDate } = useLocalDate()
@@ -17,7 +18,7 @@ const depositDate = ref(toLocalDate())
 const submitting = ref(false)
 
 async function handleSubmit() {
-  if (!amount.value || amount.value < 100000) return
+  if (!amount.value || amount.value < (fundSettings.value?.min_savings_minor ?? 100000)) return
 
   submitting.value = true
 
@@ -93,13 +94,14 @@ async function handleSubmit() {
                 v-model.number="amount"
                 type="number"
                 required
-                min="100000"
+                :min="fundSettings?.min_savings_minor ?? 100000"
                 step="1000"
-                placeholder="120000"
+                :placeholder="String(fundSettings?.min_savings_adult ?? 120000)"
                 class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
               />
               <p class="text-xs text-gray-500 mt-1">
-                Mínimo: $100.000 (menores) / $120.000 (mayores)
+                Mínimo: {{ formatCOP(fundSettings?.min_savings_minor ?? 100000) }} (menores)
+                / {{ formatCOP(fundSettings?.min_savings_adult ?? 120000) }} (mayores)
               </p>
             </div>
 

--- a/app/components/PenaltyModal.vue
+++ b/app/components/PenaltyModal.vue
@@ -15,25 +15,38 @@ const emit = defineEmits<{
   saved: []
 }>()
 
+type PenaltyReason = 'absence' | 'late_arrival' | 'other'
+
 const supabase = useSupabase()
 const toast = useToast()
+const { settings: fundSettings } = useFundSettings()
 
 const profileId = ref('')
-const reason = ref<'absence' | 'late_arrival' | 'other'>('absence')
-const amount = ref(30000)
+const reason = ref<PenaltyReason>('absence')
+const amount = ref(0)
 const submitting = ref(false)
 
-watch(reason, (val) => {
-  if (val === 'absence') amount.value = 30000
-  else if (val === 'late_arrival') amount.value = 10000
-  else amount.value = 0
-})
-
-const reasonLabel: Record<string, string> = {
-  absence: 'Inasistencia — $30.000',
-  late_arrival: 'Llegada tarde (15+ min) — $10.000',
-  other: 'Otro motivo',
+/** Monto de multa definido por los estatutos para un motivo dado. */
+function penaltyAmountFor(r: PenaltyReason): number {
+  if (!fundSettings.value) return 0
+  if (r === 'absence') return fundSettings.value.penalty_absence
+  if (r === 'late_arrival') return fundSettings.value.penalty_late_arrival
+  return 0
 }
+
+// Mantiene el monto sincronizado con el motivo y los parámetros del fondo.
+// Para "otro motivo" el monto queda libre para que el admin lo defina.
+watch([reason, fundSettings], () => {
+  if (reason.value !== 'other') {
+    amount.value = penaltyAmountFor(reason.value)
+  }
+}, { immediate: true })
+
+const reasonLabel = computed<Record<string, string>>(() => ({
+  absence: `Inasistencia — ${formatCOP(penaltyAmountFor('absence'))}`,
+  late_arrival: `Llegada tarde (15+ min) — ${formatCOP(penaltyAmountFor('late_arrival'))}`,
+  other: 'Otro motivo',
+}))
 
 const isAmountReadonly = computed(() => reason.value !== 'other')
 
@@ -60,7 +73,7 @@ async function handleSubmit() {
   toast.success('Multa registrada correctamente.')
   profileId.value = ''
   reason.value = 'absence'
-  amount.value = 30000
+  amount.value = penaltyAmountFor('absence')
   emit('saved')
   emit('close')
 }

--- a/app/composables/useActivityPermissions.ts
+++ b/app/composables/useActivityPermissions.ts
@@ -1,0 +1,114 @@
+import type { ActivityStatus, MemberRole } from '~~/types/database'
+
+/**
+ * "Reloj" global que se actualiza cada 30 segundos. Lo usamos para
+ * que el `effectiveStatus` cambie en vivo cuando una actividad
+ * `scheduled` alcanza su hora de inicio sin necesidad de recargar.
+ *
+ * Se inicializa una sola vez (la primera vez que se monta un
+ * componente que pide permisos) y queda activo durante la sesión.
+ */
+export function useGlobalClock(): Ref<number> {
+  const now = useState<number>('activity-clock-now', () => Date.now())
+  const initialized = useState<boolean>('activity-clock-initialized', () => false)
+
+  if (!initialized.value && typeof window !== 'undefined') {
+    initialized.value = true
+    setInterval(() => {
+      now.value = Date.now()
+    }, 30_000)
+  }
+
+  return now
+}
+
+/**
+ * Calcula el estado efectivo de una actividad combinando el
+ * `status` guardado en BD con `start_at`: una `scheduled` cuya
+ * hora ya pasó se trata como `in_progress`. Espejo de la función
+ * SQL `effective_activity_status()`.
+ */
+export function effectiveActivityStatus(
+  status: ActivityStatus | null,
+  startAt: string | null,
+  nowMs: number,
+): ActivityStatus | null {
+  if (!status) return null
+  if (status !== 'scheduled') return status
+  if (!startAt) return 'in_progress'
+  return Date.parse(startAt) <= nowMs ? 'in_progress' : 'scheduled'
+}
+
+/**
+ * Permisos sobre una actividad. La regla viene de los estatutos:
+ *
+ *   - El admin puede ver y modificar cualquier actividad mientras
+ *     no esté `finished`. Es el único que puede reabrir una.
+ *   - Un miembro del comité asignado puede ver y modificarla
+ *     mientras no esté `finished` (incluso si está `scheduled`,
+ *     para preparar gastos / inventario antes del evento).
+ *   - Cualquier otro miembro solo entra al detalle cuando está
+ *     `finished`. Mientras está `scheduled` o `in_progress` la ve
+ *     en la lista con su badge pero no entra al detalle.
+ */
+export interface ActivityPermissionInput {
+  currentUserId: Ref<string | null>
+  currentUserRole: Ref<MemberRole | null>
+  activityStatus: Ref<ActivityStatus | null>
+  /** Fecha/hora de inicio. `null` para actividades pre-migración. */
+  activityStartAt: Ref<string | null>
+  /** IDs de los miembros del comité asignado a la actividad. */
+  committeeMemberIds: Ref<string[]>
+}
+
+export function useActivityPermissions(input: ActivityPermissionInput) {
+  const nowMs = useGlobalClock()
+
+  const isAdmin = computed(() => input.currentUserRole.value === 'admin')
+
+  const isCommitteeMember = computed(() => {
+    const id = input.currentUserId.value
+    return !!id && input.committeeMemberIds.value.includes(id)
+  })
+
+  // Estado efectivo: rebaja `scheduled` a `in_progress` si la hora
+  // ya pasó. Espejo de `effective_activity_status()` en SQL.
+  const effectiveStatus = computed(() =>
+    effectiveActivityStatus(input.activityStatus.value, input.activityStartAt.value, nowMs.value),
+  )
+
+  // Acceso al detalle: si está finalizada, todos. Si está
+  // `scheduled` o `in_progress`, solo admin o comité.
+  const canViewDetail = computed(() => {
+    if (effectiveStatus.value === 'finished') return true
+    return isAdmin.value || isCommitteeMember.value
+  })
+
+  // Edición de gastos / inventario / ventas: cualquier estado
+  // distinto de `finished`, y solo admin o comité.
+  const canEdit = computed(() => {
+    if (effectiveStatus.value === 'finished') return false
+    return isAdmin.value || isCommitteeMember.value
+  })
+
+  // Finalizar: admin o comité, mientras no esté ya `finished`.
+  const canFinalize = computed(() => {
+    if (effectiveStatus.value === 'finished') return false
+    return isAdmin.value || isCommitteeMember.value
+  })
+
+  // Reabrir: solo admin, y solo si está `finished`.
+  const canReopen = computed(() => {
+    return isAdmin.value && effectiveStatus.value === 'finished'
+  })
+
+  return {
+    isAdmin,
+    isCommitteeMember,
+    effectiveStatus,
+    canViewDetail,
+    canEdit,
+    canFinalize,
+    canReopen,
+  }
+}

--- a/app/composables/useFundSettings.ts
+++ b/app/composables/useFundSettings.ts
@@ -1,0 +1,84 @@
+import type { FundSettings } from '~~/types/database'
+
+/**
+ * Acceso a los parámetros configurables del fondo (`fund_settings`),
+ * con histórico por año.
+ *
+ * - `useFundSettings()` → parámetros del año en curso.
+ * - `useFundSettings(2025)` → parámetros del año 2025 (útil para
+ *   recalcular liquidaciones pasadas con sus valores originales).
+ *
+ * Si el año solicitado aún no tiene configuración propia, cae al
+ * año configurado más reciente que sea anterior o igual al pedido.
+ *
+ * El resultado se cachea por año en estado global, por lo que
+ * varios componentes que pidan el mismo año comparten una sola
+ * consulta. La carga se dispara automáticamente en el primer uso.
+ */
+export function useFundSettings(year?: number) {
+  const targetYear = year ?? new Date().getFullYear()
+  const supabase = useSupabase()
+
+  const settings = useState<FundSettings | null>(
+    `fund-settings-${targetYear}`,
+    () => null,
+  )
+  const loading = useState<boolean>(
+    `fund-settings-loading-${targetYear}`,
+    () => false,
+  )
+  const error = useState<string | null>(
+    `fund-settings-error-${targetYear}`,
+    () => null,
+  )
+
+  /**
+   * Carga los parámetros del año objetivo. Usa la caché salvo que
+   * `force` sea true (p. ej. tras guardar cambios en el panel).
+   */
+  async function load(force = false): Promise<FundSettings | null> {
+    if (settings.value && !force) return settings.value
+
+    loading.value = true
+    error.value = null
+
+    const { data, error: dbError } = await supabase
+      .from('fund_settings')
+      .select('*')
+      .lte('year', targetYear)
+      .order('year', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (dbError) {
+      error.value = dbError.message
+    }
+    else {
+      settings.value = (data as FundSettings | null)
+      if (!settings.value) {
+        error.value = `No hay parámetros configurados para el año ${targetYear}.`
+      }
+    }
+
+    loading.value = false
+    return settings.value
+  }
+
+  // Dispara la carga la primera vez que se usa este año.
+  if (!settings.value && !loading.value) {
+    load()
+  }
+
+  return {
+    /** Parámetros del año objetivo (reactivo, `null` mientras carga). */
+    settings,
+    /** `true` mientras hay una consulta en curso. */
+    loading,
+    /** Mensaje de error si la carga falló, `null` si todo va bien. */
+    error,
+    /** Carga manual (respeta la caché). */
+    load,
+    /** Fuerza una recarga desde la base de datos. */
+    refresh: () => load(true),
+  }
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -49,6 +49,7 @@ const navSections: NavSection[] = [
       { to: '/dashboard', label: 'Inicio', icon: 'home' },
       { to: '/extracto', label: 'Mis Movimientos', icon: 'list' },
       { to: '/prestamos', label: 'Préstamos', icon: 'banknotes' },
+      { to: '/actividades', label: 'Actividades', icon: 'sparkles' },
     ],
   },
   {
@@ -66,7 +67,6 @@ const navSections: NavSection[] = [
       { to: '/admin/miembros', label: 'Miembros', icon: 'users' },
       { to: '/admin/retiros', label: 'Retiros', icon: 'banknotes' },
       { to: '/admin/reuniones', label: 'Reuniones', icon: 'calendar' },
-      { to: '/admin/actividades', label: 'Actividades', icon: 'sparkles' },
       { to: '/admin/inversiones', label: 'Inversiones', icon: 'trending' },
       { to: '/admin/balance', label: 'Balance', icon: 'chart' },
       { to: '/admin/cierre-anual', label: 'Cierre Anual', icon: 'gift' },

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -70,6 +70,7 @@ const navSections: NavSection[] = [
       { to: '/admin/inversiones', label: 'Inversiones', icon: 'trending' },
       { to: '/admin/balance', label: 'Balance', icon: 'chart' },
       { to: '/admin/cierre-anual', label: 'Cierre Anual', icon: 'gift' },
+      { to: '/admin/parametros', label: 'Parámetros', icon: 'cog' },
     ],
   },
 ]
@@ -194,6 +195,10 @@ async function handleLogout() {
               </svg>
               <svg v-else-if="item.icon === 'gift'" class="w-[18px] h-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
+              </svg>
+              <svg v-else-if="item.icon === 'cog'" class="w-[18px] h-[18px] shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 0 1 0 .255c-.007.378.138.75.43.991l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 0 1 0-.255c.007-.378-.138-.75-.43-.991l-1.004-.828a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281Z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
               </svg>
               <span class="truncate">{{ item.label }}</span>
             </NuxtLink>

--- a/app/pages/actividades/[id].vue
+++ b/app/pages/actividades/[id].vue
@@ -1,0 +1,1189 @@
+<script setup lang="ts">
+import type { RealtimeChannel } from '@supabase/supabase-js'
+import type { ActivityStatus, MemberRole } from '~~/types/database'
+
+interface ActivityDetail {
+  id: string
+  name: string
+  activity_date: string
+  start_at: string | null
+  status: ActivityStatus
+  finished_at: string | null
+  team_id: string | null
+  teams: {
+    name: string
+    team_members: { profile_id: string }[]
+  } | null
+}
+
+interface ExpenseRow {
+  id: string
+  description: string
+  amount: number
+  created_at: string
+}
+
+interface ProductRow {
+  id: string
+  name: string
+  cost_price: number
+  selling_price: number
+  stock_quantity: number
+  created_at: string
+}
+
+interface SaleRow {
+  id: string
+  quantity: number
+  total_price: number
+  buyer_id: string | null
+  buyer_name: string | null
+  product_id: string
+  created_at: string
+  activity_products: { name: string } | null
+  seller: { full_name: string } | null
+  buyer: { full_name: string } | null
+}
+
+interface MemberOption {
+  id: string
+  full_name: string
+}
+
+definePageMeta({
+  middleware: 'auth',
+  layout: 'default',
+})
+
+const route = useRoute()
+const router = useRouter()
+const supabase = useSupabase()
+const toast = useToast()
+
+const activityId = route.params.id as string
+
+const currentUserId = ref<string | null>(null)
+const currentUserRole = ref<MemberRole | null>(null)
+
+const activity = ref<ActivityDetail | null>(null)
+const expenses = ref<ExpenseRow[]>([])
+const products = ref<ProductRow[]>([])
+const sales = ref<SaleRow[]>([])
+const members = ref<MemberOption[]>([])
+const loading = ref(true)
+const accessDenied = ref(false)
+
+// Forms (solo si canEdit)
+const expenseDescription = ref('')
+const expenseAmount = ref<number | null>(null)
+const addingExpense = ref(false)
+
+const productName = ref('')
+const productCostPrice = ref<number | null>(null)
+const productSellingPrice = ref<number | null>(null)
+const productStock = ref<number | null>(null)
+const addingProduct = ref(false)
+
+const editingExpense = ref<ExpenseRow | null>(null)
+const savingExpense = ref(false)
+
+const editingProduct = ref<ProductRow | null>(null)
+const savingProduct = ref(false)
+
+const deleteTarget = ref<{ kind: 'expense' | 'product' | 'sale'; id: string; label: string } | null>(null)
+const deleting = ref(false)
+
+// Modal Nueva Venta / Editar Venta
+const saleModalOpen = ref(false)
+const editingSale = ref<SaleRow | null>(null)
+
+// Modales de finalizar / reabrir
+const finalizeOpen = ref(false)
+const finalizing = ref(false)
+const reopenOpen = ref(false)
+const reopening = ref(false)
+
+let channel: RealtimeChannel | null = null
+
+// ---- Permisos ----
+const committeeMemberIds = computed(() =>
+  activity.value?.teams?.team_members.map(m => m.profile_id) ?? [],
+)
+
+const activityStatus = computed<ActivityStatus | null>(() => activity.value?.status ?? null)
+const activityStartAt = computed<string | null>(() => activity.value?.start_at ?? null)
+
+const {
+  isAdmin,
+  isCommitteeMember,
+  effectiveStatus,
+  canViewDetail,
+  canEdit,
+  canFinalize,
+  canReopen,
+} = useActivityPermissions({
+  currentUserId,
+  currentUserRole,
+  activityStatus,
+  activityStartAt,
+  committeeMemberIds,
+})
+
+// El POS de ventas solo cuando la actividad efectivamente está
+// "En curso" (la hora de inicio ya llegó). Si está `scheduled`,
+// el comité puede registrar gastos e inventario, pero las ventas
+// se desbloquean al cruzar la hora.
+const canSell = computed(() => canEdit.value && effectiveStatus.value === 'in_progress')
+
+// Exportar PDF: solo admin o miembros del comité, y únicamente
+// cuando la actividad está cerrada (los números ya no cambian).
+const canExport = computed(() =>
+  (isAdmin.value || isCommitteeMember.value) && effectiveStatus.value === 'finished',
+)
+
+function handleExportPdf() {
+  if (!activity.value) return
+
+  exportActivityReportPdf({
+    activity: {
+      name: activity.value.name,
+      activity_date: activity.value.activity_date,
+      start_at: activity.value.start_at,
+      finished_at: activity.value.finished_at,
+      team_name: activity.value.teams?.name ?? null,
+    },
+    expenses: expenses.value.map(e => ({
+      description: e.description,
+      amount: e.amount,
+    })),
+    products: products.value.map(p => ({
+      name: p.name,
+      cost_price: p.cost_price,
+      selling_price: p.selling_price,
+      stock_quantity: p.stock_quantity,
+      sold: soldOf(p.id),
+      available: availableOf(p),
+    })),
+    sales: sales.value.map(s => ({
+      product_name: s.activity_products?.name ?? '—',
+      quantity: s.quantity,
+      buyer_label: buyerLabel(s),
+      seller_label: s.seller?.full_name ?? '—',
+      total_price: s.total_price,
+    })),
+  })
+
+  toast.success('Reporte PDF abierto en nueva pestaña. Guárdalo con Ctrl/Cmd + S.')
+}
+
+async function loadCurrentUser() {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return
+
+  currentUserId.value = user.id
+
+  const { data } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (data) currentUserRole.value = (data as { role: MemberRole }).role
+}
+
+async function loadData() {
+  const [activityRes, expensesRes, productsRes, salesRes, membersRes] = await Promise.all([
+    supabase
+      .from('activities')
+      .select('id, name, activity_date, start_at, status, finished_at, team_id, teams(name, team_members(profile_id))')
+      .eq('id', activityId)
+      .single(),
+    supabase
+      .from('activity_expenses')
+      .select('id, description, amount, created_at')
+      .eq('activity_id', activityId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('activity_products')
+      .select('id, name, cost_price, selling_price, stock_quantity, created_at')
+      .eq('activity_id', activityId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('activity_sales')
+      .select('id, quantity, total_price, buyer_id, buyer_name, product_id, created_at, activity_products(name), seller:profiles!seller_id(full_name), buyer:profiles!buyer_id(full_name)')
+      .eq('activity_id', activityId)
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('profiles')
+      .select('id, full_name')
+      .order('full_name'),
+  ])
+
+  activity.value = (activityRes.data as unknown as ActivityDetail | null) ?? null
+  expenses.value = (expensesRes.data as unknown as ExpenseRow[]) ?? []
+  products.value = (productsRes.data as unknown as ProductRow[]) ?? []
+  sales.value = (salesRes.data as unknown as SaleRow[]) ?? []
+  members.value = (membersRes.data as unknown as MemberOption[]) ?? []
+  loading.value = false
+}
+
+// Etiqueta de comprador para la tabla: nombre del miembro (vía
+// join `buyer_id`) o el texto libre (`buyer_name`) o "—".
+function buyerLabel(sale: SaleRow): string {
+  return sale.buyer?.full_name ?? sale.buyer_name ?? '—'
+}
+
+// ---- Matemática financiera del evento (derivada, en tiempo real) ----
+const totalExpenses = computed(() =>
+  expenses.value.reduce((sum, e) => sum + e.amount, 0),
+)
+
+const totalInventoryCost = computed(() =>
+  products.value.reduce((sum, p) => sum + p.cost_price * p.stock_quantity, 0),
+)
+
+const totalCosts = computed(() => totalExpenses.value + totalInventoryCost.value)
+
+const grossIncome = computed(() =>
+  sales.value.reduce((sum, s) => sum + s.total_price, 0),
+)
+
+const netProfit = computed(() => grossIncome.value - totalCosts.value)
+
+function soldOf(productId: string): number {
+  return sales.value
+    .filter(s => s.product_id === productId)
+    .reduce((sum, s) => sum + s.quantity, 0)
+}
+
+function availableOf(product: ProductRow): number {
+  return product.stock_quantity - soldOf(product.id)
+}
+
+// Productos para el modal de venta (con stock disponible calculado).
+const productOptions = computed(() =>
+  products.value.map(p => ({
+    id: p.id,
+    name: p.name,
+    selling_price: p.selling_price,
+    available: availableOf(p),
+  })),
+)
+
+// ---- Acciones (todas dependen de canEdit en el server, vía RLS) ----
+async function addExpense() {
+  if (!expenseDescription.value.trim() || !expenseAmount.value || expenseAmount.value <= 0) return
+
+  addingExpense.value = true
+  const { error } = await supabase.from('activity_expenses').insert({
+    activity_id: activityId,
+    description: expenseDescription.value.trim(),
+    amount: expenseAmount.value,
+  })
+  addingExpense.value = false
+
+  if (error) {
+    toast.error('Error al registrar el gasto.')
+    return
+  }
+
+  toast.success('Gasto registrado.')
+  expenseDescription.value = ''
+  expenseAmount.value = null
+  await loadData()
+}
+
+async function addProduct() {
+  if (
+    !productName.value.trim()
+    || productCostPrice.value === null || productCostPrice.value < 0
+    || productSellingPrice.value === null || productSellingPrice.value < 0
+    || productStock.value === null || productStock.value < 0
+  ) return
+
+  addingProduct.value = true
+  const { error } = await supabase.from('activity_products').insert({
+    activity_id: activityId,
+    name: productName.value.trim(),
+    cost_price: productCostPrice.value,
+    selling_price: productSellingPrice.value,
+    stock_quantity: productStock.value,
+  })
+  addingProduct.value = false
+
+  if (error) {
+    toast.error('Error al crear el producto.')
+    return
+  }
+
+  toast.success('Producto agregado al inventario.')
+  productName.value = ''
+  productCostPrice.value = null
+  productSellingPrice.value = null
+  productStock.value = null
+  await loadData()
+}
+
+function openEditExpense(expense: ExpenseRow) {
+  editingExpense.value = { ...expense }
+}
+
+async function saveExpenseEdit() {
+  if (!editingExpense.value) return
+  const e = editingExpense.value
+
+  if (!e.description.trim() || !e.amount || e.amount <= 0) return
+
+  savingExpense.value = true
+  const { error } = await supabase
+    .from('activity_expenses')
+    .update({
+      description: e.description.trim(),
+      amount: e.amount,
+    })
+    .eq('id', e.id)
+  savingExpense.value = false
+
+  if (error) {
+    toast.error('Error al actualizar el gasto.')
+    return
+  }
+
+  toast.success('Gasto actualizado.')
+  editingExpense.value = null
+  await loadData()
+}
+
+function openEditProduct(product: ProductRow) {
+  editingProduct.value = { ...product }
+}
+
+async function saveProductEdit() {
+  if (!editingProduct.value) return
+  const p = editingProduct.value
+
+  if (
+    !p.name.trim()
+    || p.cost_price < 0 || p.selling_price < 0 || p.stock_quantity < 0
+  ) return
+
+  if (p.stock_quantity < soldOf(p.id)) {
+    toast.error(`El stock no puede ser menor a las ${soldOf(p.id)} unidades ya vendidas.`)
+    return
+  }
+
+  savingProduct.value = true
+  const { error } = await supabase
+    .from('activity_products')
+    .update({
+      name: p.name.trim(),
+      cost_price: p.cost_price,
+      selling_price: p.selling_price,
+      stock_quantity: p.stock_quantity,
+    })
+    .eq('id', p.id)
+  savingProduct.value = false
+
+  if (error) {
+    toast.error('Error al actualizar el producto.')
+    return
+  }
+
+  toast.success('Producto actualizado.')
+  editingProduct.value = null
+  await loadData()
+}
+
+function askDeleteExpense(expense: ExpenseRow) {
+  deleteTarget.value = { kind: 'expense', id: expense.id, label: `el gasto "${expense.description}"` }
+}
+
+function askDeleteProduct(product: ProductRow) {
+  deleteTarget.value = {
+    kind: 'product',
+    id: product.id,
+    label: `el producto "${product.name}" y todas sus ventas`,
+  }
+}
+
+function askDeleteSale(sale: SaleRow) {
+  deleteTarget.value = {
+    kind: 'sale',
+    id: sale.id,
+    label: `la venta de ${sale.quantity} × ${sale.activity_products?.name ?? 'producto'} (${formatCOP(sale.total_price)})`,
+  }
+}
+
+// ---- Editar venta ----
+function openEditSale(sale: SaleRow) {
+  editingSale.value = sale
+  saleModalOpen.value = true
+}
+
+function closeSaleModal() {
+  saleModalOpen.value = false
+  editingSale.value = null
+}
+
+const editingSalePayload = computed(() => {
+  if (!editingSale.value) return null
+  const s = editingSale.value
+  return {
+    id: s.id,
+    product_id: s.product_id,
+    quantity: s.quantity,
+    buyer_id: s.buyer_id,
+    buyer_name: s.buyer_name,
+  }
+})
+
+async function confirmDelete() {
+  if (!deleteTarget.value) return
+  deleting.value = true
+  const table = deleteTarget.value.kind === 'expense'
+    ? 'activity_expenses'
+    : deleteTarget.value.kind === 'product'
+      ? 'activity_products'
+      : 'activity_sales'
+  const { error } = await supabase.from(table).delete().eq('id', deleteTarget.value.id)
+  deleting.value = false
+
+  if (error) {
+    toast.error(`No se pudo eliminar: ${error.message}`)
+    return
+  }
+
+  toast.success('Registro eliminado.')
+  deleteTarget.value = null
+  await loadData()
+}
+
+// ---- Finalizar / Reabrir actividad ----
+async function confirmFinalize() {
+  finalizing.value = true
+  const { error } = await supabase.rpc('finish_activity', { p_activity_id: activityId })
+  finalizing.value = false
+
+  if (error) {
+    toast.error(`No se pudo finalizar: ${error.message}`)
+    return
+  }
+
+  toast.success('Actividad finalizada. Ya es visible para todos los miembros.')
+  finalizeOpen.value = false
+  await loadData()
+}
+
+async function confirmReopen() {
+  reopening.value = true
+  const { error } = await supabase.rpc('reopen_activity', { p_activity_id: activityId })
+  reopening.value = false
+
+  if (error) {
+    toast.error(`No se pudo reabrir: ${error.message}`)
+    return
+  }
+
+  toast.success('Actividad reabierta. El comité puede volver a editar.')
+  reopenOpen.value = false
+  await loadData()
+}
+
+onMounted(async () => {
+  await loadCurrentUser()
+  await loadData()
+
+  // Si la actividad existe pero el usuario no tiene permiso para ver
+  // el detalle (está in_progress y no es admin/comité), redirigimos.
+  if (activity.value && !canViewDetail.value) {
+    accessDenied.value = true
+    return
+  }
+
+  // Realtime: el dashboard se actualiza en vivo a medida que los
+  // miembros del comité registran ventas, gastos o productos.
+  channel = supabase
+    .channel(`activity-detail-${activityId}`)
+    .on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'activities', filter: `id=eq.${activityId}` },
+      () => loadData(),
+    )
+    .on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'activity_expenses', filter: `activity_id=eq.${activityId}` },
+      () => loadData(),
+    )
+    .on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'activity_products', filter: `activity_id=eq.${activityId}` },
+      () => loadData(),
+    )
+    .on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'activity_sales', filter: `activity_id=eq.${activityId}` },
+      () => loadData(),
+    )
+    .subscribe()
+})
+
+onUnmounted(() => {
+  if (channel) supabase.removeChannel(channel)
+})
+</script>
+
+<template>
+  <div>
+    <!-- Header -->
+    <div class="mb-8">
+      <NuxtLink to="/actividades" class="text-sm text-gray-400 hover:text-white transition">
+        &larr; Volver a Actividades
+      </NuxtLink>
+      <div v-if="activity" class="mt-4 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div class="flex items-center gap-3">
+            <h1 class="text-2xl font-bold text-white">{{ activity.name }}</h1>
+            <span
+              v-if="effectiveStatus === 'scheduled'"
+              class="px-2.5 py-1 text-xs font-semibold rounded-full bg-blue-500/20 text-blue-400 uppercase tracking-wider"
+            >
+              Programada
+            </span>
+            <span
+              v-else-if="effectiveStatus === 'in_progress'"
+              class="px-2.5 py-1 text-xs font-semibold rounded-full bg-yellow-500/20 text-yellow-400 uppercase tracking-wider"
+            >
+              En curso
+            </span>
+            <span
+              v-else
+              class="px-2.5 py-1 text-xs font-semibold rounded-full bg-emerald-500/20 text-emerald-400 uppercase tracking-wider"
+            >
+              Finalizada
+            </span>
+          </div>
+          <p class="text-gray-400 mt-1">
+            <span v-if="activity.start_at">{{ formatDatetime(activity.start_at) }}</span>
+            <span v-else>{{ formatDate(activity.activity_date) }}</span>
+            <span v-if="activity.teams"> · {{ activity.teams.name }}</span>
+            <span v-if="activity.status === 'finished' && activity.finished_at" class="text-gray-500">
+              · cerrada el {{ formatDate(activity.finished_at.slice(0, 10)) }}
+            </span>
+          </p>
+        </div>
+
+        <!-- Acciones de cabecera -->
+        <div class="flex flex-wrap items-center gap-2">
+          <button
+            v-if="canSell && products.length > 0"
+            class="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500 transition"
+            @click="(editingSale = null, saleModalOpen = true)"
+          >
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+            </svg>
+            Nueva Venta
+          </button>
+          <button
+            v-if="canFinalize"
+            class="inline-flex items-center gap-1.5 rounded-lg bg-yellow-600/90 px-4 py-2 text-sm font-semibold text-white hover:bg-yellow-500 transition"
+            @click="finalizeOpen = true"
+          >
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+            </svg>
+            Finalizar actividad
+          </button>
+          <button
+            v-if="canExport"
+            class="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500 transition"
+            @click="handleExportPdf"
+          >
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 8.25H7.5a2.25 2.25 0 0 0-2.25 2.25v9a2.25 2.25 0 0 0 2.25 2.25h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25H15M9 12l3 3m0 0 3-3m-3 3V2.25" />
+            </svg>
+            Exportar PDF
+          </button>
+          <button
+            v-if="canReopen"
+            class="inline-flex items-center gap-1.5 rounded-lg bg-gray-700 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-600 transition"
+            @click="reopenOpen = true"
+          >
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+            </svg>
+            Reabrir
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Skeleton -->
+    <div v-if="loading" class="space-y-4">
+      <div class="animate-pulse bg-gray-900 rounded-2xl h-28 border border-gray-800" />
+      <div class="animate-pulse bg-gray-900 rounded-2xl h-64 border border-gray-800" />
+    </div>
+
+    <div v-else-if="!activity" class="bg-gray-900 rounded-2xl border border-gray-800 p-8 text-center">
+      <p class="text-gray-400">La actividad no existe.</p>
+    </div>
+
+    <!-- Acceso denegado: actividad en curso, usuario no es admin ni del comité -->
+    <div v-else-if="accessDenied || !canViewDetail" class="bg-gray-900 rounded-2xl border border-gray-800 p-8 text-center">
+      <div class="w-12 h-12 mx-auto rounded-full bg-yellow-500/10 flex items-center justify-center mb-4">
+        <svg class="w-6 h-6 text-yellow-400" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+        </svg>
+      </div>
+      <h2 class="text-lg font-semibold text-white">
+        <template v-if="effectiveStatus === 'scheduled'">Esta actividad aún no comienza</template>
+        <template v-else>Esta actividad está en curso</template>
+      </h2>
+      <p class="text-sm text-gray-400 mt-1">
+        Solo los miembros del comité organizador pueden ver el detalle hasta que la actividad sea finalizada. Podrás ver todos los movimientos al cierre.
+      </p>
+      <button
+        class="mt-6 rounded-lg bg-gray-800 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 transition"
+        @click="router.push('/actividades')"
+      >
+        Volver a Actividades
+      </button>
+    </div>
+
+    <template v-else>
+      <!-- ==================== DASHBOARD FINANCIERO ==================== -->
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10">
+        <div class="bg-gray-900 rounded-2xl border border-gray-800 p-5">
+          <p class="text-xs text-gray-400 uppercase tracking-wider">Costos Totales</p>
+          <p class="text-2xl font-bold text-white mt-1">{{ formatCOP(totalCosts) }}</p>
+          <p class="text-xs text-gray-500 mt-1">
+            Gastos {{ formatCOP(totalExpenses) }} · Inventario {{ formatCOP(totalInventoryCost) }}
+          </p>
+        </div>
+        <div class="bg-gray-900 rounded-2xl border border-gray-800 p-5">
+          <p class="text-xs text-gray-400 uppercase tracking-wider">Ingresos Brutos</p>
+          <p class="text-2xl font-bold text-blue-400 mt-1">{{ formatCOP(grossIncome) }}</p>
+          <p class="text-xs text-gray-500 mt-1">{{ sales.length }} venta(s) registrada(s)</p>
+        </div>
+        <div class="bg-gray-900 rounded-2xl border border-gray-800 p-5">
+          <p class="text-xs text-gray-400 uppercase tracking-wider">Ganancia Neta</p>
+          <p
+            class="text-2xl font-bold mt-1"
+            :class="netProfit >= 0 ? 'text-emerald-400' : 'text-red-400'"
+          >
+            {{ formatCOP(netProfit) }}
+          </p>
+          <p class="text-xs text-gray-500 mt-1">Ingresos − Costos Totales</p>
+        </div>
+      </div>
+
+      <!-- Aviso: actividad aún no inicia (scheduled-pendiente) -->
+      <div
+        v-if="effectiveStatus === 'scheduled' && canEdit"
+        class="mb-6 rounded-2xl border border-blue-500/20 bg-blue-500/5 px-5 py-3"
+      >
+        <p class="text-sm text-blue-300">
+          Esta actividad está <strong>programada</strong> para
+          <span v-if="activity?.start_at">{{ formatDatetime(activity.start_at) }}</span>.
+          Puedes preparar gastos e inventario; las ventas se habilitan automáticamente al llegar la hora.
+        </p>
+      </div>
+
+      <!-- Aviso si está finalizada y el usuario no es admin -->
+      <div
+        v-if="effectiveStatus === 'finished' && !isAdmin"
+        class="mb-6 rounded-2xl border border-emerald-500/20 bg-emerald-500/5 px-5 py-3"
+      >
+        <p class="text-sm text-emerald-300">
+          Esta actividad ya fue finalizada. Estás viendo el cierre en modo solo lectura.
+        </p>
+      </div>
+
+      <!-- ==================== GASTOS GENERALES ==================== -->
+      <div class="mb-10">
+        <h2 class="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">Gastos Generales</h2>
+
+        <div v-if="canEdit" class="bg-gray-900 rounded-2xl border border-gray-800 p-6 mb-4">
+          <h3 class="text-sm font-medium text-white mb-4">Nuevo Gasto</h3>
+          <form class="flex flex-col sm:flex-row gap-4" @submit.prevent="addExpense">
+            <div class="flex-1">
+              <label for="expense-description" class="block text-sm font-medium text-gray-300 mb-1">Descripción</label>
+              <input
+                id="expense-description"
+                v-model="expenseDescription"
+                type="text"
+                required
+                placeholder="Alquiler de sillas, sonido..."
+                class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+              />
+            </div>
+            <div class="w-full sm:w-48">
+              <label for="expense-amount" class="block text-sm font-medium text-gray-300 mb-1">Monto (COP)</label>
+              <input
+                id="expense-amount"
+                v-model.number="expenseAmount"
+                type="number"
+                required
+                min="1"
+                placeholder="0"
+                class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+              />
+            </div>
+            <div class="flex items-end">
+              <button
+                type="submit"
+                :disabled="addingExpense"
+                class="w-full sm:w-auto rounded-lg bg-emerald-600 px-6 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {{ addingExpense ? 'Agregando...' : 'Agregar' }}
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <div v-if="expenses.length === 0" class="bg-gray-900 rounded-2xl border border-gray-800 p-8 text-center">
+          <p class="text-gray-400">No hay gastos registrados.</p>
+        </div>
+        <div v-else class="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
+          <table class="w-full">
+            <thead>
+              <tr class="border-b border-gray-800">
+                <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Descripción</th>
+                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Monto</th>
+                <th v-if="canEdit" class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="expense in expenses"
+                :key="expense.id"
+                class="border-b border-gray-800/50 last:border-0 hover:bg-gray-800/30 transition"
+              >
+                <td class="px-6 py-4">
+                  <span class="text-sm font-medium text-white">{{ expense.description }}</span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <span class="text-sm text-gray-300">{{ formatCOP(expense.amount) }}</span>
+                </td>
+                <td v-if="canEdit" class="px-6 py-4 text-right">
+                  <div class="flex items-center justify-end gap-2">
+                    <button
+                      class="rounded-md bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                      title="Editar"
+                      @click="openEditExpense(expense)"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                      </svg>
+                    </button>
+                    <button
+                      class="rounded-md bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
+                      title="Eliminar"
+                      @click="askDeleteExpense(expense)"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- ==================== INVENTARIO ==================== -->
+      <div class="mb-10">
+        <h2 class="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">Inventario</h2>
+
+        <div v-if="canEdit" class="bg-gray-900 rounded-2xl border border-gray-800 p-6 mb-4">
+          <h3 class="text-sm font-medium text-white mb-4">Nuevo Producto</h3>
+          <form class="space-y-4" @submit.prevent="addProduct">
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label for="product-name" class="block text-sm font-medium text-gray-300 mb-1">Nombre</label>
+                <input
+                  id="product-name"
+                  v-model="productName"
+                  type="text"
+                  required
+                  placeholder="Cerveza, gaseosa, empanada..."
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+                />
+              </div>
+              <div>
+                <label for="product-stock" class="block text-sm font-medium text-gray-300 mb-1">Cantidad comprada (stock)</label>
+                <input
+                  id="product-stock"
+                  v-model.number="productStock"
+                  type="number"
+                  required
+                  min="0"
+                  placeholder="30"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+                />
+              </div>
+              <div>
+                <label for="product-cost" class="block text-sm font-medium text-gray-300 mb-1">Costo por unidad (COP)</label>
+                <input
+                  id="product-cost"
+                  v-model.number="productCostPrice"
+                  type="number"
+                  required
+                  min="0"
+                  placeholder="2000"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+                />
+              </div>
+              <div>
+                <label for="product-price" class="block text-sm font-medium text-gray-300 mb-1">Precio de venta (COP)</label>
+                <input
+                  id="product-price"
+                  v-model.number="productSellingPrice"
+                  type="number"
+                  required
+                  min="0"
+                  placeholder="4000"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+                />
+              </div>
+            </div>
+            <button
+              type="submit"
+              :disabled="addingProduct"
+              class="rounded-lg bg-emerald-600 px-6 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {{ addingProduct ? 'Agregando...' : 'Agregar Producto' }}
+            </button>
+          </form>
+        </div>
+
+        <div v-if="products.length === 0" class="bg-gray-900 rounded-2xl border border-gray-800 p-8 text-center">
+          <p class="text-gray-400">No hay productos en el inventario.</p>
+        </div>
+        <div v-else class="bg-gray-900 rounded-2xl border border-gray-800 overflow-x-auto">
+          <table class="w-full">
+            <thead>
+              <tr class="border-b border-gray-800">
+                <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Producto</th>
+                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Costo</th>
+                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Venta</th>
+                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Stock</th>
+                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Vendidas</th>
+                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Disponible</th>
+                <th v-if="canEdit" class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="product in products"
+                :key="product.id"
+                class="border-b border-gray-800/50 last:border-0 hover:bg-gray-800/30 transition"
+              >
+                <td class="px-6 py-4">
+                  <span class="text-sm font-medium text-white">{{ product.name }}</span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <span class="text-sm text-gray-400">{{ formatCOP(product.cost_price) }}</span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <span class="text-sm text-gray-300">{{ formatCOP(product.selling_price) }}</span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <span class="text-sm text-gray-300">{{ product.stock_quantity }}</span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <span class="text-sm text-gray-300">{{ soldOf(product.id) }}</span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <span
+                    class="text-sm font-semibold"
+                    :class="availableOf(product) > 0 ? 'text-emerald-400' : 'text-red-400'"
+                  >
+                    {{ availableOf(product) }}
+                  </span>
+                </td>
+                <td v-if="canEdit" class="px-6 py-4 text-right">
+                  <button
+                    class="rounded-md bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                    title="Editar producto / stock"
+                    @click="openEditProduct(product)"
+                  >
+                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                    </svg>
+                  </button>
+                  <button
+                    class="ml-2 rounded-md bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
+                    title="Eliminar"
+                    @click="askDeleteProduct(product)"
+                  >
+                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- ==================== VENTAS ==================== -->
+      <div>
+        <h2 class="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">Ventas Registradas</h2>
+
+        <div v-if="sales.length === 0" class="bg-gray-900 rounded-2xl border border-gray-800 p-8 text-center">
+          <p class="text-gray-400">Aún no hay ventas registradas.</p>
+          <p v-if="canSell && products.length > 0" class="text-sm text-gray-500 mt-1">
+            Usa el botón <strong class="text-emerald-400">"Nueva Venta"</strong> arriba para registrar la primera.
+          </p>
+          <p v-else-if="canEdit && effectiveStatus === 'scheduled'" class="text-sm text-gray-500 mt-1">
+            Las ventas se habilitan automáticamente al llegar la hora de inicio.
+          </p>
+        </div>
+        <div v-else class="bg-gray-900 rounded-2xl border border-gray-800 overflow-x-auto">
+          <table class="w-full">
+            <thead>
+              <tr class="border-b border-gray-800">
+                <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Producto</th>
+                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Cantidad</th>
+                <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Comprador</th>
+                <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Vendedor</th>
+                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Total</th>
+                <th v-if="canEdit" class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="sale in sales"
+                :key="sale.id"
+                class="border-b border-gray-800/50 last:border-0 hover:bg-gray-800/30 transition"
+              >
+                <td class="px-6 py-4">
+                  <span class="text-sm font-medium text-white">{{ sale.activity_products?.name ?? '—' }}</span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <span class="text-sm text-gray-300">{{ sale.quantity }}</span>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="text-sm text-gray-300">{{ buyerLabel(sale) }}</span>
+                </td>
+                <td class="px-6 py-4">
+                  <span class="text-sm text-gray-300">{{ sale.seller?.full_name ?? '—' }}</span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <span class="text-sm font-semibold text-emerald-400">{{ formatCOP(sale.total_price) }}</span>
+                </td>
+                <td v-if="canEdit" class="px-6 py-4 text-right">
+                  <div class="flex items-center justify-end gap-2">
+                    <button
+                      class="rounded-md bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                      title="Editar venta"
+                      @click="openEditSale(sale)"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                      </svg>
+                    </button>
+                    <button
+                      class="rounded-md bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
+                      title="Eliminar venta"
+                      @click="askDeleteSale(sale)"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+
+    <!-- Modal Nueva Venta / Editar Venta -->
+    <ActivitySaleModal
+      :visible="saleModalOpen"
+      :activity-id="activityId"
+      :products="productOptions"
+      :members="members"
+      :editing-sale="editingSalePayload"
+      @close="closeSaleModal"
+      @saved="loadData"
+    />
+
+    <!-- Modal editar gasto -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="editingExpense" class="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div class="absolute inset-0 bg-black/60" @click="editingExpense = null" />
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Editar Gasto</h2>
+            <form class="space-y-4" @submit.prevent="saveExpenseEdit">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Descripción</label>
+                <input
+                  v-model="editingExpense.description"
+                  type="text"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Monto (COP)</label>
+                <input
+                  v-model.number="editingExpense.amount"
+                  type="number"
+                  required
+                  min="1"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="editingExpense = null"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="savingExpense"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ savingExpense ? 'Guardando...' : 'Guardar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <!-- Modal editar producto -->
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div v-if="editingProduct" class="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div class="absolute inset-0 bg-black/60" @click="editingProduct = null" />
+          <div class="relative w-full max-w-md bg-gray-900 rounded-2xl border border-gray-800 shadow-2xl p-8">
+            <h2 class="text-xl font-bold text-white mb-6">Editar Producto</h2>
+            <form class="space-y-4" @submit.prevent="saveProductEdit">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Nombre</label>
+                <input
+                  v-model="editingProduct.name"
+                  type="text"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">
+                  Stock (cantidad comprada/disponible)
+                </label>
+                <input
+                  v-model.number="editingProduct.stock_quantity"
+                  type="number"
+                  required
+                  min="0"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+                <p class="text-xs text-gray-500 mt-1">
+                  Ya vendidas: {{ soldOf(editingProduct.id) }}. Aumenta el stock si compraste más durante el evento.
+                </p>
+              </div>
+              <div class="grid grid-cols-2 gap-3">
+                <div>
+                  <label class="block text-sm font-medium text-gray-300 mb-1">Costo (COP)</label>
+                  <input
+                    v-model.number="editingProduct.cost_price"
+                    type="number"
+                    required
+                    min="0"
+                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                  />
+                </div>
+                <div>
+                  <label class="block text-sm font-medium text-gray-300 mb-1">Venta (COP)</label>
+                  <input
+                    v-model.number="editingProduct.selling_price"
+                    type="number"
+                    required
+                    min="0"
+                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                  />
+                </div>
+              </div>
+              <div class="flex gap-2 pt-2">
+                <button
+                  type="button"
+                  class="flex-1 rounded-lg bg-gray-700 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+                  @click="editingProduct = null"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  :disabled="savingProduct"
+                  class="flex-1 rounded-lg bg-emerald-600 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 transition disabled:opacity-50"
+                >
+                  {{ savingProduct ? 'Guardando...' : 'Guardar' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <ConfirmModal
+      :visible="deleteTarget !== null"
+      title="Eliminar registro"
+      :message="`¿Seguro que quieres eliminar ${deleteTarget?.label ?? ''}? Esta acción no se puede deshacer.`"
+      :loading="deleting"
+      @cancel="deleteTarget = null"
+      @confirm="confirmDelete"
+    />
+
+    <ConfirmModal
+      :visible="finalizeOpen"
+      title="Finalizar actividad"
+      message="¿Confirmar el cierre? Tras finalizar, todos los miembros podrán ver el detalle pero ya no se podrán registrar gastos, productos ni ventas. Solo un admin puede reabrirla."
+      variant="warning"
+      confirm-label="Sí, finalizar"
+      :loading="finalizing"
+      @cancel="finalizeOpen = false"
+      @confirm="confirmFinalize"
+    />
+
+    <ConfirmModal
+      :visible="reopenOpen"
+      title="Reabrir actividad"
+      message="¿Reabrir esta actividad? Volverá a estado 'En curso' y el comité podrá editar gastos, inventario y ventas."
+      variant="warning"
+      confirm-label="Sí, reabrir"
+      :loading="reopening"
+      @cancel="reopenOpen = false"
+      @confirm="confirmReopen"
+    />
+  </div>
+</template>

--- a/app/pages/actividades/index.vue
+++ b/app/pages/actividades/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { ActivityStatus, MemberRole } from '~~/types/database'
+
 interface ProfileOption {
   id: string
   full_name: string
@@ -24,47 +26,62 @@ interface SelectedMember {
   role_title: string
 }
 
-interface Activity {
+interface ActivityRow {
   id: string
   name: string
   activity_date: string
+  start_at: string | null
+  status: ActivityStatus
+  finished_at: string | null
   team_id: string | null
-  costs: number
-  net_profits: number
   teams: {
     name: string
+    team_members: { profile_id: string }[]
   } | null
+  // Filas hijas para derivar los totales financieros en tiempo real.
+  activity_expenses: { amount: number }[]
+  activity_products: { cost_price: number; stock_quantity: number }[]
+  activity_sales: { total_price: number }[]
 }
 
 definePageMeta({
-  middleware: 'admin',
+  middleware: 'auth',
   layout: 'default',
 })
 
 const supabase = useSupabase()
 const toast = useToast()
 
+// Reloj global: refresca `effectiveStatusOf` cada 30s para que
+// una actividad `scheduled` pase a "En curso" en vivo al llegar
+// su hora, sin recargar.
+const nowMs = useGlobalClock()
+
+// Usuario actual
+const currentUserId = ref<string | null>(null)
+const currentUserRole = ref<MemberRole | null>(null)
+const isAdmin = computed(() => currentUserRole.value === 'admin')
+
 const members = ref<ProfileOption[]>([])
 const teams = ref<TeamWithMembers[]>([])
-const activities = ref<Activity[]>([])
+const activities = ref<ActivityRow[]>([])
 const loading = ref(true)
 
-// Form comité
+// Form comité (admin)
 const teamName = ref('')
 const teamTerm = ref('')
 const selectedMembers = ref<SelectedMember[]>([])
 const creatingTeam = ref(false)
 
-// Form actividad
+// Form actividad (admin)
 const activityName = ref('')
-const { toLocalDate } = useLocalDate()
+const { toLocalDate, toLocalDatetime, toISOWithOffset } = useLocalDate()
 const activityDate = ref(toLocalDate())
+const activityStartAt = ref(toLocalDatetime())
 const activityTeamId = ref('')
-const activityCosts = ref<number | null>(null)
-const activityProfits = ref<number | null>(null)
 const creatingActivity = ref(false)
 
-// Edición
+// Edición (admin)
 interface EditingTeam {
   id: string
   name: string
@@ -72,32 +89,114 @@ interface EditingTeam {
   members: SelectedMember[]
 }
 const editingTeam = ref<EditingTeam | null>(null)
-const editingActivity = ref<Activity | null>(null)
+
+interface EditingActivity {
+  id: string
+  name: string
+  activity_date: string
+  /** Valor para el input datetime-local (`YYYY-MM-DDTHH:mm`). */
+  start_at_local: string
+  team_id: string | null
+}
+const editingActivity = ref<EditingActivity | null>(null)
 const saving = ref(false)
 
-// Borrado
+// Borrado (admin)
 const deleteTarget = ref<{ kind: 'team' | 'activity'; id: string; label: string } | null>(null)
 const deleting = ref(false)
 
+async function loadCurrentUser() {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return
+
+  currentUserId.value = user.id
+
+  const { data } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (data) currentUserRole.value = (data as { role: MemberRole }).role
+}
+
 async function loadData() {
+  // El listado siempre trae las filas hijas: para admin / comité se
+  // muestran los totales; para el resto, las actividades `finished`
+  // también muestran sus totales (transparencia post-cierre).
   const [membersResult, teamsResult, activitiesResult] = await Promise.all([
-    supabase.from('profiles').select('id, full_name'),
+    supabase.from('profiles').select('id, full_name').order('full_name'),
     supabase
       .from('teams')
       .select('id, name, term, team_members(role_title, profiles(id, full_name))')
       .order('created_at', { ascending: false }),
     supabase
       .from('activities')
-      .select('id, name, activity_date, team_id, costs, net_profits, teams(name)')
+      .select('id, name, activity_date, start_at, status, finished_at, team_id, teams(name, team_members(profile_id)), activity_expenses(amount), activity_products(cost_price, stock_quantity), activity_sales(total_price)')
       .order('activity_date', { ascending: false }),
   ])
 
   members.value = (membersResult.data as unknown as ProfileOption[]) ?? []
   teams.value = (teamsResult.data as unknown as TeamWithMembers[]) ?? []
-  activities.value = (activitiesResult.data as unknown as Activity[]) ?? []
+  activities.value = (activitiesResult.data as unknown as ActivityRow[]) ?? []
   loading.value = false
 }
 
+// ---- Permisos por fila ----
+
+// El usuario actual es miembro del comité asignado a la actividad.
+function isMemberOfCommittee(a: ActivityRow): boolean {
+  const id = currentUserId.value
+  if (!id) return false
+  return a.teams?.team_members.some(tm => tm.profile_id === id) ?? false
+}
+
+// Estado efectivo: rebaja `scheduled` a `in_progress` si la hora
+// ya pasó. Espejo de `effective_activity_status()` en SQL.
+function effectiveStatusOf(a: ActivityRow): ActivityStatus {
+  return effectiveActivityStatus(a.status, a.start_at, nowMs.value) ?? a.status
+}
+
+// Puede entrar al detalle: si está finalizada, todos; si está
+// `scheduled` o `in_progress`, solo admin o comité.
+function canViewDetail(a: ActivityRow): boolean {
+  if (effectiveStatusOf(a) === 'finished') return true
+  return isAdmin.value || isMemberOfCommittee(a)
+}
+
+// Muestra los totales financieros: el usuario tiene visibilidad
+// sobre la actividad. Coincide con `canViewDetail` (única regla).
+function canSeeNumbers(a: ActivityRow): boolean {
+  return canViewDetail(a)
+}
+
+// ---- Totales financieros derivados (única fuente de la verdad) ----
+function costsOf(a: ActivityRow): number {
+  const expenses = a.activity_expenses.reduce((sum, e) => sum + e.amount, 0)
+  const inventory = a.activity_products.reduce(
+    (sum, p) => sum + p.cost_price * p.stock_quantity,
+    0,
+  )
+  return expenses + inventory
+}
+
+function grossOf(a: ActivityRow): number {
+  return a.activity_sales.reduce((sum, s) => sum + s.total_price, 0)
+}
+
+function netOf(a: ActivityRow): number {
+  return grossOf(a) - costsOf(a)
+}
+
+// Total para el admin: suma de ganancias de actividades finalizadas.
+// (Las en curso pueden tener números aún en movimiento.)
+const totalProfits = computed(() =>
+  activities.value
+    .filter(a => a.status === 'finished')
+    .reduce((sum, a) => sum + netOf(a), 0),
+)
+
+// ---- Crear comité (admin) ----
 async function createTeam() {
   if (!teamName.value.trim() || !teamTerm.value.trim()) return
 
@@ -141,16 +240,21 @@ async function createTeam() {
 }
 
 async function createActivity() {
-  if (!activityName.value.trim() || !activityDate.value) return
+  if (!activityName.value.trim() || !activityDate.value || !activityStartAt.value) return
 
   creatingActivity.value = true
+
+  // El estado inicial depende de la hora de inicio: si todavía no
+  // llega, nace `scheduled`; si ya pasó, arranca `in_progress`.
+  const startIso = toISOWithOffset(activityStartAt.value)
+  const initialStatus = Date.parse(startIso) > Date.now() ? 'scheduled' : 'in_progress'
 
   const { error } = await supabase.from('activities').insert({
     name: activityName.value.trim(),
     activity_date: activityDate.value,
+    start_at: startIso,
+    status: initialStatus,
     team_id: activityTeamId.value || null,
-    costs: activityCosts.value ?? 0,
-    net_profits: activityProfits.value ?? 0,
   })
 
   creatingActivity.value = false
@@ -163,9 +267,8 @@ async function createActivity() {
   toast.success('Actividad registrada correctamente.')
   activityName.value = ''
   activityDate.value = toLocalDate()
+  activityStartAt.value = toLocalDatetime()
   activityTeamId.value = ''
-  activityCosts.value = null
-  activityProfits.value = null
   await loadData()
 }
 
@@ -222,7 +325,7 @@ async function saveTeamEdit() {
     return
   }
 
-  // Re-sincronizar miembros: borrar todos los existentes y re-insertar los actuales.
+  // Re-sincronizar miembros: borrar todos los existentes y re-insertar.
   const { error: delError } = await supabase.from('team_members').delete().eq('team_id', t.id)
   if (delError) {
     saving.value = false
@@ -250,12 +353,24 @@ async function saveTeamEdit() {
   await loadData()
 }
 
-function openEditActivity(a: Activity) {
-  editingActivity.value = { ...a }
+function openEditActivity(a: ActivityRow) {
+  editingActivity.value = {
+    id: a.id,
+    name: a.name,
+    activity_date: a.activity_date,
+    // Si la actividad no tenía hora (pre-migración), pre-llenamos
+    // con el inicio del día activo para no enviar string vacío.
+    start_at_local: a.start_at
+      ? toLocalDatetime(new Date(a.start_at))
+      : toLocalDatetime(new Date(a.activity_date + 'T08:00:00')),
+    team_id: a.team_id,
+  }
 }
 
 async function saveActivityEdit() {
   if (!editingActivity.value) return
+  if (!editingActivity.value.start_at_local) return
+
   saving.value = true
   const a = editingActivity.value
   const { error } = await supabase
@@ -263,9 +378,8 @@ async function saveActivityEdit() {
     .update({
       name: a.name,
       activity_date: a.activity_date,
+      start_at: toISOWithOffset(a.start_at_local),
       team_id: a.team_id || null,
-      costs: a.costs,
-      net_profits: a.net_profits,
     })
     .eq('id', a.id)
   saving.value = false
@@ -282,7 +396,7 @@ function askDeleteTeam(team: TeamWithMembers) {
   deleteTarget.value = { kind: 'team', id: team.id, label: `el comité "${team.name}"` }
 }
 
-function askDeleteActivity(a: Activity) {
+function askDeleteActivity(a: ActivityRow) {
   deleteTarget.value = { kind: 'activity', id: a.id, label: `la actividad "${a.name}"` }
 }
 
@@ -301,35 +415,21 @@ async function confirmDelete() {
   await loadData()
 }
 
-function formatCOP(value: number): string {
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0,
-  }).format(value)
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr + 'T12:00:00').toLocaleDateString('es-CO', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  })
-}
-
-const totalProfits = computed(() =>
-  activities.value.reduce((sum, a) => sum + (a.net_profits ?? 0), 0),
-)
-
-onMounted(loadData)
+onMounted(async () => {
+  await loadCurrentUser()
+  await loadData()
+})
 </script>
 
 <template>
   <div>
     <!-- Header -->
     <div class="mb-8">
-      <h1 class="text-2xl font-bold text-white">Comités y Actividades</h1>
-      <p class="text-gray-400 mt-1">Gestión de comités organizadores y actividades del fondo.</p>
+      <h1 class="text-2xl font-bold text-white">Actividades</h1>
+      <p class="text-gray-400 mt-1">
+        <template v-if="isAdmin">Gestión de comités organizadores y actividades del fondo.</template>
+        <template v-else>Selecciona una actividad para ver sus detalles o registrar ventas.</template>
+      </p>
     </div>
 
     <!-- Skeleton -->
@@ -339,8 +439,8 @@ onMounted(loadData)
     </div>
 
     <template v-else>
-      <!-- ==================== COMITÉS ==================== -->
-      <div class="mb-10">
+      <!-- ==================== COMITÉS (solo admin) ==================== -->
+      <div v-if="isAdmin" class="mb-10">
         <h2 class="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">Comités</h2>
 
         <!-- Form nuevo comité -->
@@ -372,7 +472,6 @@ onMounted(loadData)
               </div>
             </div>
 
-            <!-- Selector de miembros -->
             <div>
               <p class="text-sm font-medium text-gray-300 mb-2">Integrantes</p>
               <div class="flex flex-wrap gap-2 mb-3">
@@ -390,7 +489,6 @@ onMounted(loadData)
                 </button>
               </div>
 
-              <!-- Cargos de los seleccionados -->
               <div v-if="selectedMembers.length > 0" class="space-y-2 pt-3 border-t border-gray-800">
                 <p class="text-xs font-medium text-gray-400 uppercase tracking-wider mb-2">Cargos</p>
                 <div
@@ -472,19 +570,22 @@ onMounted(loadData)
       <!-- ==================== ACTIVIDADES ==================== -->
       <div>
         <div class="flex items-center justify-between mb-4">
-          <h2 class="text-sm font-medium text-gray-400 uppercase tracking-wider">Actividades</h2>
-          <div v-if="activities.length > 0" class="text-right">
-            <p class="text-xs text-gray-400">Ganancia total</p>
+          <h2 class="text-sm font-medium text-gray-400 uppercase tracking-wider">
+            <template v-if="isAdmin">Actividades</template>
+            <template v-else>Listado</template>
+          </h2>
+          <div v-if="isAdmin && activities.length > 0" class="text-right">
+            <p class="text-xs text-gray-400">Ganancia total (finalizadas)</p>
             <p class="text-lg font-bold text-emerald-400">{{ formatCOP(totalProfits) }}</p>
           </div>
         </div>
 
-        <!-- Form nueva actividad -->
-        <div class="bg-gray-900 rounded-2xl border border-gray-800 p-6 mb-4">
+        <!-- Form nueva actividad (admin) -->
+        <div v-if="isAdmin" class="bg-gray-900 rounded-2xl border border-gray-800 p-6 mb-4">
           <h3 class="text-sm font-medium text-white mb-4">Nueva Actividad</h3>
           <form @submit.prevent="createActivity" class="space-y-4">
-            <div class="flex gap-4">
-              <div class="flex-1">
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              <div class="sm:col-span-3">
                 <label for="activity-name" class="block text-sm font-medium text-gray-300 mb-1">Nombre</label>
                 <input
                   id="activity-name"
@@ -495,8 +596,8 @@ onMounted(loadData)
                   class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
                 />
               </div>
-              <div class="w-48">
-                <label for="activity-date" class="block text-sm font-medium text-gray-300 mb-1">Fecha</label>
+              <div>
+                <label for="activity-date" class="block text-sm font-medium text-gray-300 mb-1">Fecha del evento</label>
                 <input
                   id="activity-date"
                   v-model="activityDate"
@@ -505,45 +606,39 @@ onMounted(loadData)
                   class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
                 />
               </div>
+              <div class="sm:col-span-2">
+                <label for="activity-start" class="block text-sm font-medium text-gray-300 mb-1">
+                  Hora de inicio
+                </label>
+                <input
+                  id="activity-start"
+                  v-model="activityStartAt"
+                  type="datetime-local"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+                />
+                <p class="text-xs text-gray-500 mt-1">
+                  La actividad queda <span class="text-blue-400">"Programada"</span> hasta este momento, luego pasa automáticamente a <span class="text-yellow-400">"En curso"</span>.
+                </p>
+              </div>
             </div>
 
-            <div class="flex gap-4">
-              <div class="flex-1">
-                <label for="activity-team" class="block text-sm font-medium text-gray-300 mb-1">Comité Responsable</label>
-                <select
-                  id="activity-team"
-                  v-model="activityTeamId"
-                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
-                >
-                  <option value="">Sin comité</option>
-                  <option v-for="team in teams" :key="team.id" :value="team.id">
-                    {{ team.name }} ({{ team.term }})
-                  </option>
-                </select>
-              </div>
-              <div class="w-48">
-                <label for="activity-costs" class="block text-sm font-medium text-gray-300 mb-1">Costos (COP)</label>
-                <input
-                  id="activity-costs"
-                  v-model.number="activityCosts"
-                  type="number"
-                  min="0"
-                  placeholder="0"
-                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
-                />
-              </div>
-              <div class="w-48">
-                <label for="activity-profits" class="block text-sm font-medium text-gray-300 mb-1">Ganancia Neta (COP)</label>
-                <input
-                  id="activity-profits"
-                  v-model.number="activityProfits"
-                  type="number"
-                  min="0"
-                  placeholder="0"
-                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
-                />
-              </div>
+            <div>
+              <label for="activity-team" class="block text-sm font-medium text-gray-300 mb-1">Comité Responsable</label>
+              <select
+                id="activity-team"
+                v-model="activityTeamId"
+                class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+              >
+                <option value="">Sin comité</option>
+                <option v-for="team in teams" :key="team.id" :value="team.id">
+                  {{ team.name }} ({{ team.term }})
+                </option>
+              </select>
             </div>
+            <p class="text-xs text-gray-500">
+              Los costos y la ganancia se calculan automáticamente desde los gastos, el inventario y las ventas registradas en el detalle de la actividad.
+            </p>
 
             <button
               type="submit"
@@ -559,7 +654,7 @@ onMounted(loadData)
         <div v-if="activities.length === 0" class="bg-gray-900 rounded-2xl border border-gray-800 p-8 text-center">
           <p class="text-gray-400">No hay actividades registradas.</p>
         </div>
-        <div v-else class="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
+        <div v-else class="bg-gray-900 rounded-2xl border border-gray-800 overflow-x-auto">
           <table class="w-full">
             <thead>
               <tr class="border-b border-gray-800">
@@ -567,7 +662,8 @@ onMounted(loadData)
                 <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Fecha</th>
                 <th class="text-left text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Comité</th>
                 <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Costos</th>
-                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Ganancia Neta</th>
+                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Ingresos</th>
+                <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Ganancia</th>
                 <th class="text-right text-xs font-medium text-gray-400 uppercase tracking-wider px-6 py-4">Acciones</th>
               </tr>
             </thead>
@@ -578,40 +674,100 @@ onMounted(loadData)
                 class="border-b border-gray-800/50 last:border-0 hover:bg-gray-800/30 transition"
               >
                 <td class="px-6 py-4">
-                  <span class="text-sm font-medium text-white">{{ activity.name }}</span>
+                  <div class="flex items-center gap-2">
+                    <NuxtLink
+                      v-if="canViewDetail(activity)"
+                      :to="`/actividades/${activity.id}`"
+                      class="text-sm font-medium text-white hover:text-emerald-400 transition"
+                    >
+                      {{ activity.name }}
+                    </NuxtLink>
+                    <span v-else class="text-sm font-medium text-gray-400">{{ activity.name }}</span>
+                    <span
+                      v-if="effectiveStatusOf(activity) === 'scheduled'"
+                      class="px-2 py-0.5 text-[10px] font-semibold rounded-full bg-blue-500/20 text-blue-400 uppercase tracking-wider"
+                    >
+                      Programada
+                    </span>
+                    <span
+                      v-else-if="effectiveStatusOf(activity) === 'in_progress'"
+                      class="px-2 py-0.5 text-[10px] font-semibold rounded-full bg-yellow-500/20 text-yellow-400 uppercase tracking-wider"
+                    >
+                      En curso
+                    </span>
+                    <span
+                      v-else
+                      class="px-2 py-0.5 text-[10px] font-semibold rounded-full bg-emerald-500/20 text-emerald-400 uppercase tracking-wider"
+                    >
+                      Finalizada
+                    </span>
+                  </div>
                 </td>
                 <td class="px-6 py-4">
-                  <span class="text-sm text-gray-300">{{ formatDate(activity.activity_date) }}</span>
+                  <span v-if="activity.start_at" class="text-sm text-gray-300">{{ formatDatetime(activity.start_at) }}</span>
+                  <span v-else class="text-sm text-gray-300">{{ formatDate(activity.activity_date) }}</span>
                 </td>
                 <td class="px-6 py-4">
                   <span class="text-sm text-gray-300">{{ activity.teams?.name ?? '—' }}</span>
                 </td>
                 <td class="px-6 py-4 text-right">
-                  <span class="text-sm text-gray-400">{{ formatCOP(activity.costs) }}</span>
+                  <span v-if="canSeeNumbers(activity)" class="text-sm text-gray-400">{{ formatCOP(costsOf(activity)) }}</span>
+                  <span v-else class="text-sm text-gray-600">—</span>
                 </td>
                 <td class="px-6 py-4 text-right">
-                  <span class="text-sm font-semibold text-emerald-400">{{ formatCOP(activity.net_profits) }}</span>
+                  <span v-if="canSeeNumbers(activity)" class="text-sm text-gray-300">{{ formatCOP(grossOf(activity)) }}</span>
+                  <span v-else class="text-sm text-gray-600">—</span>
+                </td>
+                <td class="px-6 py-4 text-right">
+                  <span
+                    v-if="canSeeNumbers(activity)"
+                    class="text-sm font-semibold"
+                    :class="netOf(activity) >= 0 ? 'text-emerald-400' : 'text-red-400'"
+                  >
+                    {{ formatCOP(netOf(activity)) }}
+                  </span>
+                  <span v-else class="text-sm text-gray-600">—</span>
                 </td>
                 <td class="px-6 py-4">
                   <div class="flex items-center justify-end gap-2">
-                    <button
-                      class="rounded-md bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
-                      title="Editar"
-                      @click="openEditActivity(activity)"
+                    <NuxtLink
+                      v-if="canViewDetail(activity)"
+                      :to="`/actividades/${activity.id}`"
+                      class="rounded-md bg-emerald-500/10 px-2.5 py-1.5 text-xs font-semibold text-emerald-400 hover:bg-emerald-500/20 transition flex items-center gap-1"
+                      title="Abrir detalle de la actividad"
                     >
-                      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                      Detalle
+                      <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
                       </svg>
-                    </button>
-                    <button
-                      class="rounded-md bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
-                      title="Eliminar"
-                      @click="askDeleteActivity(activity)"
+                    </NuxtLink>
+                    <span
+                      v-else
+                      class="rounded-md bg-gray-800 px-2.5 py-1.5 text-xs text-gray-500"
+                      title="Disponible cuando el comité finalice la actividad"
                     >
-                      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-                      </svg>
-                    </button>
+                      Disponible al finalizar
+                    </span>
+                    <template v-if="isAdmin">
+                      <button
+                        class="rounded-md bg-gray-700 p-1.5 text-gray-300 hover:bg-gray-600 hover:text-white transition"
+                        title="Editar"
+                        @click="openEditActivity(activity)"
+                      >
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                        </svg>
+                      </button>
+                      <button
+                        class="rounded-md bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20 transition"
+                        title="Eliminar"
+                        @click="askDeleteActivity(activity)"
+                      >
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                        </svg>
+                      </button>
+                    </template>
                   </div>
                 </td>
               </tr>
@@ -736,13 +892,25 @@ onMounted(loadData)
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-300 mb-1">Fecha</label>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Fecha del evento</label>
                 <input
                   v-model="editingActivity.activity_date"
                   type="date"
                   required
                   class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
                 />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-1">Hora de inicio</label>
+                <input
+                  v-model="editingActivity.start_at_local"
+                  type="datetime-local"
+                  required
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
+                />
+                <p class="text-xs text-gray-500 mt-1">
+                  Editar la hora no cambia el estado actual de la actividad.
+                </p>
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-300 mb-1">Comité</label>
@@ -755,26 +923,6 @@ onMounted(loadData)
                     {{ team.name }} ({{ team.term }})
                   </option>
                 </select>
-              </div>
-              <div class="grid grid-cols-2 gap-3">
-                <div>
-                  <label class="block text-sm font-medium text-gray-300 mb-1">Costos (COP)</label>
-                  <input
-                    v-model.number="editingActivity.costs"
-                    type="number"
-                    min="0"
-                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
-                  />
-                </div>
-                <div>
-                  <label class="block text-sm font-medium text-gray-300 mb-1">Ganancia (COP)</label>
-                  <input
-                    v-model.number="editingActivity.net_profits"
-                    type="number"
-                    min="0"
-                    class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none"
-                  />
-                </div>
               </div>
               <div class="flex gap-2 pt-2">
                 <button

--- a/app/pages/admin/cierre-anual.vue
+++ b/app/pages/admin/cierre-anual.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
+import type { FundSettings } from '~~/types/database'
+
 definePageMeta({
   middleware: 'admin',
   layout: 'default',
 })
-
-const FONDO_BASE = 300_000
 
 interface SettlementRow {
   profile_id: string
@@ -18,13 +18,48 @@ const supabase = useSupabase()
 const toast = useToast()
 
 const loading = ref(true)
+const availableYears = ref<number[]>([])
+const selectedYear = ref<number>(new Date().getFullYear())
+const fundSettings = ref<FundSettings | null>(null)
 const totalActivityProfits = ref(0)
 const totalPenaltiesCollected = ref(0)
 const settlement = ref<SettlementRow[]>([])
 
-const currentYear = new Date().getFullYear()
+/** Base que se retiene en el fondo, según los parámetros del año liquidado. */
+const yearEndBase = computed(() => fundSettings.value?.year_end_base ?? 0)
+
+/** `true` si el año seleccionado no tiene parámetros configurados. */
+const yearNotConfigured = computed(() => !loading.value && !fundSettings.value)
+
+/** Años a ofrecer en el selector: los que tienen parámetros configurados. */
+const yearOptions = computed(() => {
+  const set = new Set(availableYears.value)
+  set.add(selectedYear.value)
+  return Array.from(set).sort((a, b) => b - a)
+})
+
+async function loadYears() {
+  const { data } = await supabase
+    .from('fund_settings')
+    .select('year')
+    .order('year', { ascending: false })
+
+  availableYears.value = (data ?? []).map(r => r.year as number)
+  // Si el año actual no está configurado, usar el más reciente disponible.
+  if (!availableYears.value.includes(selectedYear.value) && availableYears.value.length) {
+    selectedYear.value = availableYears.value[0]!
+  }
+}
 
 async function loadData() {
+  loading.value = true
+
+  const year = selectedYear.value
+  const yearStart = `${year}-01-01`
+  const nextYearStart = `${year + 1}-01-01`
+
+  fundSettings.value = await useFundSettings(year).load()
+
   const [
     profilesResult,
     activitiesResult,
@@ -39,23 +74,33 @@ async function loadData() {
       .order('full_name'),
     supabase
       .from('activities')
-      .select('net_profits'),
+      .select('net_profits')
+      .gte('activity_date', yearStart)
+      .lt('activity_date', nextYearStart),
     supabase
       .from('penalties')
       .select('amount')
-      .in('status', ['paid', 'deducted_from_savings']),
+      .in('status', ['paid', 'deducted_from_savings'])
+      .gte('created_at', yearStart)
+      .lt('created_at', nextYearStart),
     supabase
       .from('contributions')
       .select('profile_id, amount')
-      .eq('status', 'approved'),
+      .eq('status', 'approved')
+      .gte('deposit_date', yearStart)
+      .lt('deposit_date', nextYearStart),
     supabase
       .from('withdrawals')
       .select('profile_id, amount')
-      .eq('status', 'approved'),
+      .eq('status', 'approved')
+      .gte('created_at', yearStart)
+      .lt('created_at', nextYearStart),
     supabase
       .from('penalties')
       .select('profile_id, amount')
-      .eq('status', 'deducted_from_savings'),
+      .eq('status', 'deducted_from_savings')
+      .gte('created_at', yearStart)
+      .lt('created_at', nextYearStart),
   ])
 
   totalActivityProfits.value = (activitiesResult.data ?? [])
@@ -81,7 +126,7 @@ async function loadData() {
 
   const profiles = profilesResult.data ?? []
   const totalExtra = totalActivityProfits.value + totalPenaltiesCollected.value
-  const utility = Math.max(0, totalExtra - FONDO_BASE)
+  const utility = Math.max(0, totalExtra - yearEndBase.value)
   const bonus = profiles.length > 0 ? utility / profiles.length : 0
 
   settlement.value = profiles.map(p => {
@@ -108,10 +153,10 @@ const totalExtraIncome = computed(
 )
 
 const utilityToDistribute = computed(
-  () => Math.max(0, totalExtraIncome.value - FONDO_BASE),
+  () => Math.max(0, totalExtraIncome.value - yearEndBase.value),
 )
 
-const baseNotReached = computed(() => totalExtraIncome.value < FONDO_BASE)
+const baseNotReached = computed(() => totalExtraIncome.value < yearEndBase.value)
 
 const memberCount = computed(() => settlement.value.length)
 
@@ -127,7 +172,10 @@ function handleExportPdf() {
   toast.success('La exportación a PDF estará disponible próximamente.')
 }
 
-onMounted(loadData)
+onMounted(async () => {
+  await loadYears()
+  await loadData()
+})
 </script>
 
 <template>
@@ -146,24 +194,40 @@ onMounted(loadData)
               </svg>
             </span>
             <span class="text-[11px] uppercase tracking-widest text-amber-300/80 font-semibold">
-              Cierre {{ currentYear }}
+              Cierre {{ selectedYear }}
             </span>
           </div>
           <h1 class="text-3xl font-bold text-white">Liquidación de Fin de Año</h1>
           <p class="text-gray-400 mt-1 max-w-2xl">
             Cálculo del reparto de utilidades entre los miembros del fondo según los estatutos.
-            Se retiene una base de {{ formatCOP(FONDO_BASE) }} para arrancar el siguiente ciclo.
+            Se retiene una base de {{ formatCOP(yearEndBase) }} para arrancar el siguiente ciclo.
           </p>
         </div>
-        <button
-          class="shrink-0 inline-flex items-center gap-2 rounded-lg bg-white/10 hover:bg-white/15 border border-white/15 px-4 py-2.5 text-sm font-semibold text-white backdrop-blur transition"
-          @click="handleExportPdf"
-        >
-          <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
-          </svg>
-          Exportar Liquidación a PDF
-        </button>
+        <div class="flex flex-col items-end gap-3">
+          <div>
+            <label class="block text-[11px] uppercase tracking-widest text-amber-300/80 font-semibold mb-1">
+              Año a liquidar
+            </label>
+            <select
+              v-model.number="selectedYear"
+              class="rounded-lg bg-white/10 border border-white/15 px-4 py-2 text-sm font-semibold text-white backdrop-blur focus:border-amber-400 focus:ring-1 focus:ring-amber-400 outline-none transition"
+              @change="loadData"
+            >
+              <option v-for="year in yearOptions" :key="year" :value="year" class="text-gray-900">
+                {{ year }}
+              </option>
+            </select>
+          </div>
+          <button
+            class="shrink-0 inline-flex items-center gap-2 rounded-lg bg-white/10 hover:bg-white/15 border border-white/15 px-4 py-2.5 text-sm font-semibold text-white backdrop-blur transition"
+            @click="handleExportPdf"
+          >
+            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+            </svg>
+            Exportar Liquidación a PDF
+          </button>
+        </div>
       </div>
     </div>
 
@@ -178,9 +242,28 @@ onMounted(loadData)
     </div>
 
     <template v-else>
+      <!-- Aviso: año sin parámetros configurados -->
+      <div
+        v-if="yearNotConfigured"
+        class="mb-6 rounded-2xl border border-red-500/30 bg-red-500/10 p-5 flex items-start gap-3"
+      >
+        <svg class="h-6 w-6 shrink-0 text-red-400 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+        </svg>
+        <div>
+          <p class="text-sm font-semibold text-red-400">
+            El año {{ selectedYear }} no tiene parámetros configurados.
+          </p>
+          <p class="text-xs text-red-400/70 mt-1">
+            La base de fin de año se está tomando como {{ formatCOP(0) }}. Configura los
+            parámetros del año en la sección <strong>Parámetros</strong> para una liquidación correcta.
+          </p>
+        </div>
+      </div>
+
       <!-- Aviso si no se supera la base -->
       <div
-        v-if="baseNotReached"
+        v-else-if="baseNotReached"
         class="mb-6 rounded-2xl border border-yellow-500/30 bg-yellow-500/10 p-5 flex items-start gap-3"
       >
         <svg class="h-6 w-6 shrink-0 text-yellow-400 mt-0.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
@@ -192,7 +275,7 @@ onMounted(loadData)
           </p>
           <p class="text-xs text-yellow-400/70 mt-1">
             Los ingresos extra ({{ formatCOP(totalExtraIncome) }}) no superan la base intocable
-            de {{ formatCOP(FONDO_BASE) }}, por lo que aún no hay utilidades para repartir.
+            de {{ formatCOP(yearEndBase) }}, por lo que aún no hay utilidades para repartir.
           </p>
         </div>
       </div>
@@ -239,7 +322,7 @@ onMounted(loadData)
             </p>
           </div>
           <p class="text-2xl font-bold text-white">
-            {{ formatCOP(FONDO_BASE) }}
+            {{ formatCOP(yearEndBase) }}
           </p>
           <p class="text-xs text-gray-500 mt-3">
             Capital que queda en el fondo para arrancar el siguiente año.

--- a/app/pages/admin/parametros.vue
+++ b/app/pages/admin/parametros.vue
@@ -27,32 +27,17 @@ interface FieldGroup {
 
 const fieldGroups: FieldGroup[] = [
   {
-    title: 'Ingreso y Admisión',
-    iconPath: 'M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 9.374 21c-2.331 0-4.512-.645-6.374-1.766Z',
-    fields: [
-      { key: 'admission_fee', label: 'Cuota de admisión', suffix: 'COP', min: 0, step: 1, hint: 'Monto que paga un miembro nuevo al ingresar al fondo.' },
-      { key: 'reentry_multiplier', label: 'Multiplicador de reingreso', suffix: '×', min: 1, step: 0.5, hint: 'La cuota de reingreso es la admisión multiplicada por este factor.' },
-      { key: 'enrollment_deadline_day', label: 'Día límite para ingresar (enero)', suffix: 'día', min: 1, max: 31, step: 1 },
-      { key: 'admission_exemption_year', label: 'Año de exención de admisión', suffix: 'año', min: 2000, step: 1, hint: 'Los miembros que ingresan desde este año están exentos del pago de admisión.' },
-      { key: 'legacy_member_cutoff_year', label: 'Año de corte de miembros antiguos', suffix: 'año', min: 2000, step: 1, hint: 'Define quiénes cuentan como "asociados antiguos" para efectos de retiro.' },
-    ],
-  },
-  {
     title: 'Ahorros',
     iconPath: 'M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z',
     fields: [
       { key: 'min_savings_minor', label: 'Cuota mínima mensual — menores', suffix: 'COP', min: 0, step: 1 },
       { key: 'min_savings_adult', label: 'Cuota mínima mensual — mayores', suffix: 'COP', min: 0, step: 1 },
-      { key: 'payment_deadline_day_january', label: 'Día límite de pago — enero', suffix: 'día', min: 1, max: 31, step: 1 },
-      { key: 'payment_deadline_day_regular', label: 'Día límite de pago — febrero a noviembre', suffix: 'día', min: 1, max: 31, step: 1, hint: 'Diciembre es flexible según la fecha de la reunión de fin de año.' },
     ],
   },
   {
     title: 'Moras y Sanciones',
     iconPath: 'M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z',
     fields: [
-      { key: 'missed_installments_for_expulsion', label: 'Cuotas atrasadas para expulsión', suffix: 'cuotas', min: 1, step: 1 },
-      { key: 'loan_default_months_for_deduction', label: 'Meses de mora para descuento automático', suffix: 'meses', min: 1, step: 1 },
       { key: 'penalty_absence', label: 'Multa por inasistencia', suffix: 'COP', min: 0, step: 1 },
       { key: 'penalty_late_arrival', label: 'Multa por llegada tarde', suffix: 'COP', min: 0, step: 1 },
     ],
@@ -67,11 +52,10 @@ const fieldGroups: FieldGroup[] = [
     ],
   },
   {
-    title: 'Cierre Anual y Junta',
+    title: 'Cierre Anual',
     iconPath: 'M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z',
     fields: [
       { key: 'year_end_base', label: 'Base retenida de fin de año', suffix: 'COP', min: 0, step: 1 },
-      { key: 'board_min_seniority_years', label: 'Antigüedad mínima para la Junta', suffix: 'años', min: 0, step: 1 },
     ],
   },
 ]
@@ -98,47 +82,27 @@ const yearOptions = computed(() => {
 
 function emptyForm(): SettingsForm {
   return {
-    admission_fee: 0,
-    reentry_multiplier: 2,
-    enrollment_deadline_day: 31,
-    admission_exemption_year: new Date().getFullYear(),
-    legacy_member_cutoff_year: new Date().getFullYear(),
     min_savings_minor: 0,
     min_savings_adult: 0,
-    payment_deadline_day_january: 30,
-    payment_deadline_day_regular: 15,
-    missed_installments_for_expulsion: 3,
-    loan_default_months_for_deduction: 2,
     penalty_absence: 0,
     penalty_late_arrival: 0,
     min_interest_rate: 2,
     loan_limit_without_guarantor: 0,
     loan_savings_percentage_cap: 80,
     year_end_base: 0,
-    board_min_seniority_years: 3,
   }
 }
 
 function rowToForm(row: FundSettings): SettingsForm {
   return {
-    admission_fee: row.admission_fee,
-    reentry_multiplier: row.reentry_multiplier,
-    enrollment_deadline_day: row.enrollment_deadline_day,
-    admission_exemption_year: row.admission_exemption_year,
-    legacy_member_cutoff_year: row.legacy_member_cutoff_year,
     min_savings_minor: row.min_savings_minor,
     min_savings_adult: row.min_savings_adult,
-    payment_deadline_day_january: row.payment_deadline_day_january,
-    payment_deadline_day_regular: row.payment_deadline_day_regular,
-    missed_installments_for_expulsion: row.missed_installments_for_expulsion,
-    loan_default_months_for_deduction: row.loan_default_months_for_deduction,
     penalty_absence: row.penalty_absence,
     penalty_late_arrival: row.penalty_late_arrival,
     min_interest_rate: row.min_interest_rate,
     loan_limit_without_guarantor: row.loan_limit_without_guarantor,
     loan_savings_percentage_cap: row.loan_savings_percentage_cap,
     year_end_base: row.year_end_base,
-    board_min_seniority_years: row.board_min_seniority_years,
   }
 }
 

--- a/app/pages/admin/parametros.vue
+++ b/app/pages/admin/parametros.vue
@@ -1,0 +1,373 @@
+<script setup lang="ts">
+import type { FundSettings } from '~~/types/database'
+
+definePageMeta({
+  middleware: 'admin',
+  layout: 'default',
+})
+
+/** Campos editables de `fund_settings` (sin `year` ni timestamps). */
+type SettingsForm = Omit<FundSettings, 'year' | 'created_at' | 'updated_at'>
+
+interface FieldDef {
+  key: keyof SettingsForm
+  label: string
+  suffix: string
+  hint?: string
+  min: number
+  max?: number
+  step: number
+}
+
+interface FieldGroup {
+  title: string
+  iconPath: string
+  fields: FieldDef[]
+}
+
+const fieldGroups: FieldGroup[] = [
+  {
+    title: 'Ingreso y Admisión',
+    iconPath: 'M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 9.374 21c-2.331 0-4.512-.645-6.374-1.766Z',
+    fields: [
+      { key: 'admission_fee', label: 'Cuota de admisión', suffix: 'COP', min: 0, step: 1, hint: 'Monto que paga un miembro nuevo al ingresar al fondo.' },
+      { key: 'reentry_multiplier', label: 'Multiplicador de reingreso', suffix: '×', min: 1, step: 0.5, hint: 'La cuota de reingreso es la admisión multiplicada por este factor.' },
+      { key: 'enrollment_deadline_day', label: 'Día límite para ingresar (enero)', suffix: 'día', min: 1, max: 31, step: 1 },
+      { key: 'admission_exemption_year', label: 'Año de exención de admisión', suffix: 'año', min: 2000, step: 1, hint: 'Los miembros que ingresan desde este año están exentos del pago de admisión.' },
+      { key: 'legacy_member_cutoff_year', label: 'Año de corte de miembros antiguos', suffix: 'año', min: 2000, step: 1, hint: 'Define quiénes cuentan como "asociados antiguos" para efectos de retiro.' },
+    ],
+  },
+  {
+    title: 'Ahorros',
+    iconPath: 'M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z',
+    fields: [
+      { key: 'min_savings_minor', label: 'Cuota mínima mensual — menores', suffix: 'COP', min: 0, step: 1 },
+      { key: 'min_savings_adult', label: 'Cuota mínima mensual — mayores', suffix: 'COP', min: 0, step: 1 },
+      { key: 'payment_deadline_day_january', label: 'Día límite de pago — enero', suffix: 'día', min: 1, max: 31, step: 1 },
+      { key: 'payment_deadline_day_regular', label: 'Día límite de pago — febrero a noviembre', suffix: 'día', min: 1, max: 31, step: 1, hint: 'Diciembre es flexible según la fecha de la reunión de fin de año.' },
+    ],
+  },
+  {
+    title: 'Moras y Sanciones',
+    iconPath: 'M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z',
+    fields: [
+      { key: 'missed_installments_for_expulsion', label: 'Cuotas atrasadas para expulsión', suffix: 'cuotas', min: 1, step: 1 },
+      { key: 'loan_default_months_for_deduction', label: 'Meses de mora para descuento automático', suffix: 'meses', min: 1, step: 1 },
+      { key: 'penalty_absence', label: 'Multa por inasistencia', suffix: 'COP', min: 0, step: 1 },
+      { key: 'penalty_late_arrival', label: 'Multa por llegada tarde', suffix: 'COP', min: 0, step: 1 },
+    ],
+  },
+  {
+    title: 'Préstamos',
+    iconPath: 'M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z',
+    fields: [
+      { key: 'min_interest_rate', label: 'Interés mínimo', suffix: '%', min: 0, step: 0.01 },
+      { key: 'loan_limit_without_guarantor', label: 'Límite de préstamo sin fiador', suffix: 'COP', min: 0, step: 1 },
+      { key: 'loan_savings_percentage_cap', label: 'Tope sin fiador (% del ahorro)', suffix: '%', min: 0, max: 100, step: 1 },
+    ],
+  },
+  {
+    title: 'Cierre Anual y Junta',
+    iconPath: 'M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z',
+    fields: [
+      { key: 'year_end_base', label: 'Base retenida de fin de año', suffix: 'COP', min: 0, step: 1 },
+      { key: 'board_min_seniority_years', label: 'Antigüedad mínima para la Junta', suffix: 'años', min: 0, step: 1 },
+    ],
+  },
+]
+
+const supabase = useSupabase()
+const toast = useToast()
+
+const loading = ref(true)
+const saving = ref(false)
+const availableYears = ref<number[]>([])
+const selectedYear = ref<number>(new Date().getFullYear())
+const updatedAt = ref<string | null>(null)
+const form = ref<SettingsForm>(emptyForm())
+
+/** `true` cuando el año seleccionado todavía no tiene fila en la BD. */
+const isNewYear = computed(() => !availableYears.value.includes(selectedYear.value))
+
+/** Años a mostrar en el selector: los configurados + el seleccionado. */
+const yearOptions = computed(() => {
+  const set = new Set(availableYears.value)
+  set.add(selectedYear.value)
+  return Array.from(set).sort((a, b) => b - a)
+})
+
+function emptyForm(): SettingsForm {
+  return {
+    admission_fee: 0,
+    reentry_multiplier: 2,
+    enrollment_deadline_day: 31,
+    admission_exemption_year: new Date().getFullYear(),
+    legacy_member_cutoff_year: new Date().getFullYear(),
+    min_savings_minor: 0,
+    min_savings_adult: 0,
+    payment_deadline_day_january: 30,
+    payment_deadline_day_regular: 15,
+    missed_installments_for_expulsion: 3,
+    loan_default_months_for_deduction: 2,
+    penalty_absence: 0,
+    penalty_late_arrival: 0,
+    min_interest_rate: 2,
+    loan_limit_without_guarantor: 0,
+    loan_savings_percentage_cap: 80,
+    year_end_base: 0,
+    board_min_seniority_years: 3,
+  }
+}
+
+function rowToForm(row: FundSettings): SettingsForm {
+  return {
+    admission_fee: row.admission_fee,
+    reentry_multiplier: row.reentry_multiplier,
+    enrollment_deadline_day: row.enrollment_deadline_day,
+    admission_exemption_year: row.admission_exemption_year,
+    legacy_member_cutoff_year: row.legacy_member_cutoff_year,
+    min_savings_minor: row.min_savings_minor,
+    min_savings_adult: row.min_savings_adult,
+    payment_deadline_day_january: row.payment_deadline_day_january,
+    payment_deadline_day_regular: row.payment_deadline_day_regular,
+    missed_installments_for_expulsion: row.missed_installments_for_expulsion,
+    loan_default_months_for_deduction: row.loan_default_months_for_deduction,
+    penalty_absence: row.penalty_absence,
+    penalty_late_arrival: row.penalty_late_arrival,
+    min_interest_rate: row.min_interest_rate,
+    loan_limit_without_guarantor: row.loan_limit_without_guarantor,
+    loan_savings_percentage_cap: row.loan_savings_percentage_cap,
+    year_end_base: row.year_end_base,
+    board_min_seniority_years: row.board_min_seniority_years,
+  }
+}
+
+async function loadYears() {
+  const { data } = await supabase
+    .from('fund_settings')
+    .select('year')
+    .order('year', { ascending: false })
+
+  availableYears.value = (data ?? []).map(r => r.year as number)
+}
+
+async function loadYear(year: number) {
+  loading.value = true
+
+  const { data } = await supabase
+    .from('fund_settings')
+    .select('*')
+    .eq('year', year)
+    .maybeSingle()
+
+  if (data) {
+    form.value = rowToForm(data as FundSettings)
+    updatedAt.value = (data as FundSettings).updated_at
+  }
+  else {
+    // Año nuevo: precargar con el año configurado más reciente como base.
+    updatedAt.value = null
+    const { data: latest } = await supabase
+      .from('fund_settings')
+      .select('*')
+      .lt('year', year)
+      .order('year', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    form.value = latest ? rowToForm(latest as FundSettings) : emptyForm()
+  }
+
+  loading.value = false
+}
+
+function addNextYear() {
+  const maxYear = availableYears.value.length
+    ? Math.max(...availableYears.value)
+    : new Date().getFullYear()
+  selectedYear.value = maxYear + 1
+  loadYear(selectedYear.value)
+}
+
+async function handleSave() {
+  const hasEmpty = Object.values(form.value).some(
+    v => v === null || v === undefined || Number.isNaN(v),
+  )
+  if (hasEmpty) {
+    toast.error('Completa todos los campos antes de guardar.')
+    return
+  }
+
+  saving.value = true
+
+  const { error } = isNewYear.value
+    ? await supabase.from('fund_settings').insert({ year: selectedYear.value, ...form.value })
+    : await supabase.from('fund_settings').update(form.value).eq('year', selectedYear.value)
+
+  saving.value = false
+
+  if (error) {
+    toast.error(`No se pudieron guardar los parámetros: ${error.message}`)
+    return
+  }
+
+  toast.success(`Parámetros de ${selectedYear.value} guardados.`)
+  // Invalida la caché compartida del composable para ese año.
+  useFundSettings(selectedYear.value).refresh()
+  await loadYears()
+  await loadYear(selectedYear.value)
+}
+
+const updatedAtLabel = computed(() => {
+  if (!updatedAt.value) return ''
+  return new Date(updatedAt.value).toLocaleDateString('es-CO', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+})
+
+onMounted(async () => {
+  await loadYears()
+  const currentYear = new Date().getFullYear()
+  selectedYear.value = availableYears.value.includes(currentYear)
+    ? currentYear
+    : (availableYears.value[0] ?? currentYear)
+  await loadYear(selectedYear.value)
+})
+</script>
+
+<template>
+  <div>
+    <!-- Encabezado -->
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-white">Parámetros del Fondo</h1>
+      <p class="text-gray-400 mt-1">
+        Valores configurables de los estatutos (cuotas, bases, límites, multas). Cada año
+        tiene su propia configuración para preservar la integridad de los cálculos pasados.
+      </p>
+    </div>
+
+    <!-- Barra de selección de año -->
+    <div class="bg-gray-900 rounded-2xl border border-gray-800 p-5 mb-6">
+      <div class="flex flex-wrap items-end gap-4">
+        <div>
+          <label class="block text-sm font-medium text-gray-300 mb-1">Año a configurar</label>
+          <select
+            v-model.number="selectedYear"
+            class="rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+            @change="loadYear(selectedYear)"
+          >
+            <option v-for="year in yearOptions" :key="year" :value="year">
+              {{ year }}
+            </option>
+          </select>
+        </div>
+
+        <button
+          type="button"
+          class="inline-flex items-center gap-2 rounded-lg bg-gray-700 px-4 py-2.5 text-sm font-semibold text-white hover:bg-gray-600 transition"
+          @click="addNextYear"
+        >
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+          </svg>
+          Configurar año siguiente
+        </button>
+
+        <div class="flex-1" />
+
+        <div class="text-right">
+          <span
+            class="inline-block px-2.5 py-1 text-xs font-semibold rounded-full"
+            :class="isNewYear
+              ? 'bg-amber-500/20 text-amber-400'
+              : 'bg-emerald-500/20 text-emerald-400'"
+          >
+            {{ isNewYear ? 'Año nuevo' : 'Configuración existente' }}
+          </span>
+          <p v-if="updatedAtLabel" class="text-[11px] text-gray-500 mt-1">
+            Última actualización: {{ updatedAtLabel }}
+          </p>
+        </div>
+      </div>
+
+      <!-- Aviso de año nuevo -->
+      <div
+        v-if="isNewYear && !loading"
+        class="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-400/90"
+      >
+        Estás configurando un año nuevo. Los valores se precargaron a partir del año
+        configurado más reciente; ajústalos según los estatutos vigentes y guarda.
+      </div>
+    </div>
+
+    <!-- Skeleton -->
+    <div v-if="loading" class="space-y-4">
+      <div
+        v-for="i in 3"
+        :key="i"
+        class="animate-pulse bg-gray-900 rounded-2xl h-56 border border-gray-800"
+      />
+    </div>
+
+    <!-- Formulario por secciones -->
+    <form v-else @submit.prevent="handleSave">
+      <div class="space-y-6">
+        <div
+          v-for="group in fieldGroups"
+          :key="group.title"
+          class="bg-gray-900 rounded-2xl border border-gray-800 p-6"
+        >
+          <div class="flex items-center gap-3 mb-5">
+            <span class="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-500/15 text-emerald-400">
+              <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.75" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" :d="group.iconPath" />
+              </svg>
+            </span>
+            <h2 class="text-lg font-semibold text-white">{{ group.title }}</h2>
+          </div>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-5">
+            <div v-for="field in group.fields" :key="field.key">
+              <label class="block text-sm font-medium text-gray-300 mb-1">
+                {{ field.label }}
+              </label>
+              <div class="relative">
+                <input
+                  v-model.number="form[field.key]"
+                  type="number"
+                  required
+                  :min="field.min"
+                  :max="field.max"
+                  :step="field.step"
+                  class="w-full rounded-lg border border-gray-700 bg-gray-800 pl-4 pr-16 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
+                />
+                <span class="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-medium text-gray-500">
+                  {{ field.suffix }}
+                </span>
+              </div>
+              <p v-if="field.hint" class="text-xs text-gray-500 mt-1">
+                {{ field.hint }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Acción -->
+      <div class="mt-6 flex items-center justify-end gap-3">
+        <span v-if="isNewYear" class="text-xs text-gray-500">
+          Se creará la configuración del año {{ selectedYear }}.
+        </span>
+        <button
+          type="submit"
+          :disabled="saving"
+          class="rounded-lg bg-emerald-600 px-6 py-2.5 text-sm font-semibold text-white hover:bg-emerald-500 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-gray-950 transition disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {{ saving ? 'Guardando...' : isNewYear ? `Crear parámetros ${selectedYear}` : 'Guardar cambios' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/app/pages/estatutos.vue
+++ b/app/pages/estatutos.vue
@@ -13,52 +13,90 @@ interface Article {
 
 const articles: Article[] = [
   {
-    id: 'ingresos',
-    title: 'Artículo I — Ingresos',
-    summary: 'Requisitos y cuotas de admisión y reingreso al fondo.',
+    id: 'ingreso',
+    title: 'Artículo I — Ingreso y Admisión',
+    summary: 'Solicitud, aprobación y cuotas de admisión y reingreso.',
     body:
-      'La admisión de un nuevo miembro al fondo tiene un costo de $70.000 COP, mientras que el reingreso de un miembro previamente retirado tiene un costo de $140.000 COP (el doble). ' +
-      'Los nuevos integrantes a partir del año 2023 están exentos del pago de admisión. ' +
-      'Todo aspirante deberá ser aceptado por la Junta Directiva y firmar conformidad con los presentes estatutos.',
+      'Para ingresar al fondo se deberá presentar la solicitud ante la asamblea, la cual deberá ser aprobada mediante votación. ' +
+      'El plazo máximo para ingresar al fondo es el 31 de enero del año en vigencia. ' +
+      'Cada miembro nuevo aportará una admisión de ochenta mil pesos ($80.000 COP); los miembros que reingresan al año inmediatamente después de haber retirado su aporte pagarán el doble ($160.000 COP). ' +
+      'Estos valores no serán devueltos a la salida final del miembro, sino que serán divididos proporcionalmente en partes iguales entre los integrantes activos al momento de la disolución del fondo.',
   },
   {
     id: 'ahorros',
     title: 'Artículo II — Ahorros',
-    summary: 'Cuotas mensuales obligatorias y fechas de pago.',
+    summary: 'Cuotas mínimas, definición del valor y fechas de pago.',
     body:
-      'La cuota mínima mensual para menores de edad es de $100.000 COP, y para mayores de edad es de $120.000 COP. ' +
-      'El valor del ahorro se define al ingresar al fondo y no puede modificarse durante todo el año en curso. ' +
-      'El plazo máximo de pago es el día 30 de cada mes, con excepción del mes de diciembre, cuya fecha límite es el día 15.',
+      'La cuota mínima de ahorro mensual es de cien mil pesos ($100.000 COP) para menores de edad y de ciento veinte mil pesos ($120.000 COP) para mayores de edad. ' +
+      'Al ingresar al fondo, el valor del ahorro mensual queda definido con la realización del primer pago y no podrá ser modificado durante el año en curso. ' +
+      'El plazo máximo para el pago de la cuota de enero es el 30 de enero. Desde febrero hasta diciembre, la cuota deberá efectuarse a más tardar el día 15 de cada mes; la cuota de diciembre queda sujeta a flexibilidad según la fecha de la reunión de fin de año. ' +
+      'La cuota podrá pagarse de manera semanal, quincenal o en un solo pago mensual.',
+  },
+  {
+    id: 'moras-ahorro',
+    title: 'Artículo III — Moras en el Ahorro',
+    summary: 'Atraso de cuotas, renegociación y expulsión.',
+    body:
+      'El miembro que incurra en el atraso de tres (3) cuotas será expulsado del fondo. ' +
+      'No obstante, durante el primer mes de atraso tendrá derecho, por una única vez, a un proceso de renegociación: en primera instancia con el Comité y, de ser necesario, en segunda instancia con la Junta. ' +
+      'Si no se logra un acuerdo en ninguna de estas instancias, el miembro será expulsado del fondo.',
   },
   {
     id: 'prestamos',
-    title: 'Artículo III — Préstamos',
-    summary: 'Condiciones, tasas y requisitos de codeudores.',
+    title: 'Artículo IV — Préstamos',
+    summary: 'Condiciones, límites, fiador y mora en créditos.',
     body:
-      'Solo los miembros activos del fondo pueden solicitar préstamos. La tasa de interés mínima es del 2% mensual. ' +
-      'Sin fiador, un miembro puede solicitar hasta $200.000 COP o el equivalente al 80% del valor ahorrado (lo que resulte menor). ' +
-      'Para montos superiores, se requiere un codeudor que sea miembro activo del fondo y cuente con capacidad de ahorro suficiente para respaldar la obligación.',
-  },
-  {
-    id: 'moras',
-    title: 'Artículo IV — Moras y Sanciones',
-    summary: 'Penalidades por incumplimiento y faltas.',
-    body:
-      'El atraso de tres cuotas consecutivas en el ahorro mensual genera la expulsión del fondo. ' +
-      'La mora de dos meses en préstamos activa el descuento automático sobre los ahorros del deudor o, en su defecto, sobre los del codeudor. ' +
-      'Llegar 15 minutos tarde a una citación genera una multa de $10.000 COP. La inasistencia a reuniones genera una multa de $30.000 COP que se descuenta directamente de los ahorros.',
+      'El dinero del fondo solo y únicamente se puede prestar a sus miembros, con un interés no menor al dos por ciento (2%). ' +
+      'El límite que se presta sin fiador es de quinientos mil pesos ($500.000 COP) o el 80% del valor ahorrado hasta el momento de la solicitud, lo que resulte menor. ' +
+      'Para valores superiores se requiere un fiador perteneciente al fondo, y la capacidad de ambos deberá cubrir el valor del préstamo. ' +
+      'Si el deudor queda en mora por dos (2) meses, automáticamente se le descontará el valor en mora de sus ahorros en el fondo; si sus ahorros no alcanzan, el descuento se aplicará sobre los ahorros del codeudor.',
   },
   {
     id: 'utilidades',
     title: 'Artículo V — Utilidades',
-    summary: 'Reparto anual y causales de pérdida del derecho.',
+    summary: 'Reparto por préstamos, base de fin de año y pérdida del derecho.',
     body:
-      'A la primera oportunidad de incumplimiento en la fecha de pago del ahorro mensual, el miembro pierde todo derecho a las utilidades anuales del fondo. ' +
-      'Al finalizar el año, se devuelven los aportes a cada miembro, dejando una base operativa de $300.000 COP en la caja del fondo para el siguiente período.',
+      'Las utilidades por préstamos serán divididas porcentualmente de acuerdo con el saldo que cada miembro tenga al cierre del año, siempre y cuando cumpla con la cuota de ahorro mensual a más tardar el día 15 del mes vigente. ' +
+      'A la primera oportunidad en que se halle el incumplimiento del ahorro mensual en la fecha estipulada, el miembro perderá automáticamente todo derecho a dichas utilidades. ' +
+      'Al final del año se devolverán los aportes, dejando todos los miembros una base de trescientos cincuenta mil pesos ($350.000 COP) de lo ahorrado. ' +
+      'Las personas antiguas que se retiran pierden cualquier beneficio de antigüedad, adaptándose a los estatutos vigentes a su reingreso.',
+  },
+  {
+    id: 'sanciones',
+    title: 'Artículo VI — Sanciones y Asistencia',
+    summary: 'Multas por inasistencia y retardo, y régimen de poderes.',
+    body:
+      'La sanción por inasistencia a las reuniones es de treinta mil pesos ($30.000 COP), descontada de los ahorros. ' +
+      'Se autoriza un máximo de dos (2) poderes consecutivos de un mismo usuario y un máximo de tres (3) poderes por usuario en un año calendario; los poderes deben hacerse llegar a la presidencia del fondo con un plazo no menor a seis (6) horas previas al inicio de la reunión citada (Acta No. 6). ' +
+      'El miembro que llegue después de quince (15) minutos de la hora estipulada a las citaciones —reuniones o actividades de integración— deberá pagar una multa de diez mil pesos ($10.000 COP). La aplicación y control de esta multa estará a cargo del Comité de Convivencia.',
+  },
+  {
+    id: 'actividades-inversiones',
+    title: 'Artículo VII — Actividades e Inversiones',
+    summary: 'Comité de actividades e inversiones para ingresos adicionales.',
+    body:
+      'Habrá un comité de actividades cuyas condiciones se fijarán en la reunión de inicio de año, con el fin de generar ingresos adicionales y promover la integración de los miembros. Un caso especial de no participación será discutido por la Junta. ' +
+      'Asimismo, el fondo realizará inversiones rentables cuyas condiciones serán definidas en la reunión de inicio de año y sometidas a votación, con el fin de generar ingresos adicionales.',
+  },
+  {
+    id: 'junta',
+    title: 'Artículo VIII — Junta Directiva',
+    summary: 'Requisitos de antigüedad y criterios de elección.',
+    body:
+      'La Junta será elegida entre los miembros con una antigüedad de tres (3) años o más, considerando criterios personales específicos como su continuidad, el pago a tiempo de sus obligaciones y su buen comportamiento personal y crediticio.',
+  },
+  {
+    id: 'retiros',
+    title: 'Artículo IX — Retiro de Miembros Antiguos',
+    summary: 'Devolución de dineros a asociados antiguos a 2022.',
+    body:
+      'A los asociados antiguos a 2022 que se retiren no se les retendrá ningún dinero de aportes ni de ahorros: se les devolverá todo el dinero que hayan allegado al fondo. ' +
+      'Sin embargo, si el retiro ocurre en un mes diferente a diciembre, el miembro perderá el derecho a recibir utilidades por los préstamos y las actividades realizadas en el año calendario (Acta No. 9). ' +
+      'Se exceptúa la entrega del dinero de la admisión para los nuevos integrantes que ingresan a partir de 2023.',
   },
 ]
 
-const openId = ref<string | null>('ingresos')
+const openId = ref<string | null>('ingreso')
 
 function toggle(id: string) {
   openId.value = openId.value === id ? null : id

--- a/app/pages/estatutos.vue
+++ b/app/pages/estatutos.vue
@@ -13,90 +13,135 @@ interface Article {
 
 const articles: Article[] = [
   {
-    id: 'ingreso',
-    title: 'Artículo I — Ingreso y Admisión',
-    summary: 'Solicitud, aprobación y cuotas de admisión y reingreso.',
+    id: 'articulo-1',
+    title: 'Artículo 1 — Ingreso al fondo',
+    summary: 'Solicitud de ingreso aprobada por votación de la asamblea.',
     body:
-      'Para ingresar al fondo se deberá presentar la solicitud ante la asamblea, la cual deberá ser aprobada mediante votación. ' +
-      'El plazo máximo para ingresar al fondo es el 31 de enero del año en vigencia. ' +
-      'Cada miembro nuevo aportará una admisión de ochenta mil pesos ($80.000 COP); los miembros que reingresan al año inmediatamente después de haber retirado su aporte pagarán el doble ($160.000 COP). ' +
-      'Estos valores no serán devueltos a la salida final del miembro, sino que serán divididos proporcionalmente en partes iguales entre los integrantes activos al momento de la disolución del fondo.',
+      'Para ingresar al fondo deberá solicitar a la asamblea su petición, la cual deberá ser aprobada por medio de votación.',
   },
   {
-    id: 'ahorros',
-    title: 'Artículo II — Ahorros',
-    summary: 'Cuotas mínimas, definición del valor y fechas de pago.',
+    id: 'articulo-2',
+    title: 'Artículo 2 — Plazo de ingreso',
+    summary: 'Fecha límite para ingresar al fondo cada año.',
     body:
-      'La cuota mínima de ahorro mensual es de cien mil pesos ($100.000 COP) para menores de edad y de ciento veinte mil pesos ($120.000 COP) para mayores de edad. ' +
-      'Al ingresar al fondo, el valor del ahorro mensual queda definido con la realización del primer pago y no podrá ser modificado durante el año en curso. ' +
-      'El plazo máximo para el pago de la cuota de enero es el 30 de enero. Desde febrero hasta diciembre, la cuota deberá efectuarse a más tardar el día 15 de cada mes; la cuota de diciembre queda sujeta a flexibilidad según la fecha de la reunión de fin de año. ' +
-      'La cuota podrá pagarse de manera semanal, quincenal o en un solo pago mensual.',
+      'El plazo máximo para ingresar al fondo es el 31 de enero del año en vigencia.',
   },
   {
-    id: 'moras-ahorro',
-    title: 'Artículo III — Moras en el Ahorro',
-    summary: 'Atraso de cuotas, renegociación y expulsión.',
+    id: 'articulo-3',
+    title: 'Artículo 3 — Cuota de admisión y reingreso',
+    summary: 'Valor de admisión, reingreso y destino del dinero.',
     body:
-      'El miembro que incurra en el atraso de tres (3) cuotas será expulsado del fondo. ' +
-      'No obstante, durante el primer mes de atraso tendrá derecho, por una única vez, a un proceso de renegociación: en primera instancia con el Comité y, de ser necesario, en segunda instancia con la Junta. ' +
-      'Si no se logra un acuerdo en ninguna de estas instancias, el miembro será expulsado del fondo.',
+      'Cada miembro nuevo, para ingresar, aportará una admisión de ochenta mil pesos ($80.000) m/cte; y los miembros que reingresan al año inmediatamente de haberse retirado, su aporte será el doble de lo anteriormente estipulado. ' +
+      'Estos valores no serán devueltos a su salida final del fondo, sino que serán proporcionalmente divididos en partes iguales entre los integrantes que estén activos en el momento de la disolución del fondo.',
   },
   {
-    id: 'prestamos',
-    title: 'Artículo IV — Préstamos',
-    summary: 'Condiciones, límites, fiador y mora en créditos.',
+    id: 'articulo-4',
+    title: 'Artículo 4 — Cuota mínima de ahorro',
+    summary: 'Monto mínimo mensual para menores y mayores de edad.',
     body:
-      'El dinero del fondo solo y únicamente se puede prestar a sus miembros, con un interés no menor al dos por ciento (2%). ' +
-      'El límite que se presta sin fiador es de quinientos mil pesos ($500.000 COP) o el 80% del valor ahorrado hasta el momento de la solicitud, lo que resulte menor. ' +
-      'Para valores superiores se requiere un fiador perteneciente al fondo, y la capacidad de ambos deberá cubrir el valor del préstamo. ' +
-      'Si el deudor queda en mora por dos (2) meses, automáticamente se le descontará el valor en mora de sus ahorros en el fondo; si sus ahorros no alcanzan, el descuento se aplicará sobre los ahorros del codeudor.',
+      'La cuota mínima de ahorro mensual para menores de edad es de cien mil pesos m/cte ($100.000) y para mayores es de ciento veinte mil pesos m/cte ($120.000).',
   },
   {
-    id: 'utilidades',
-    title: 'Artículo V — Utilidades',
-    summary: 'Reparto por préstamos, base de fin de año y pérdida del derecho.',
+    id: 'articulo-5',
+    title: 'Artículo 5 — Fechas de pago de la cuota',
+    summary: 'Plazos de pago mensual y modalidades.',
     body:
-      'Las utilidades por préstamos serán divididas porcentualmente de acuerdo con el saldo que cada miembro tenga al cierre del año, siempre y cuando cumpla con la cuota de ahorro mensual a más tardar el día 15 del mes vigente. ' +
-      'A la primera oportunidad en que se halle el incumplimiento del ahorro mensual en la fecha estipulada, el miembro perderá automáticamente todo derecho a dichas utilidades. ' +
-      'Al final del año se devolverán los aportes, dejando todos los miembros una base de trescientos cincuenta mil pesos ($350.000 COP) de lo ahorrado. ' +
-      'Las personas antiguas que se retiran pierden cualquier beneficio de antigüedad, adaptándose a los estatutos vigentes a su reingreso.',
+      'El plazo máximo para el pago de la cuota correspondiente al mes de enero será el 30 de enero. La cuota mensual de ahorro, desde febrero hasta diciembre, deberá efectuarse a más tardar el día 15 de cada mes; no obstante, la cuota del mes de diciembre quedará sujeta a flexibilidad, de acuerdo con la fecha de la reunión de fin de año. La cuota podrá pagarse de manera semanal, quincenal o en un solo pago mensual.',
   },
   {
-    id: 'sanciones',
-    title: 'Artículo VI — Sanciones y Asistencia',
-    summary: 'Multas por inasistencia y retardo, y régimen de poderes.',
+    id: 'articulo-6',
+    title: 'Artículo 6 — Atraso de cuotas',
+    summary: 'Expulsión por mora y proceso de renegociación.',
     body:
-      'La sanción por inasistencia a las reuniones es de treinta mil pesos ($30.000 COP), descontada de los ahorros. ' +
-      'Se autoriza un máximo de dos (2) poderes consecutivos de un mismo usuario y un máximo de tres (3) poderes por usuario en un año calendario; los poderes deben hacerse llegar a la presidencia del fondo con un plazo no menor a seis (6) horas previas al inicio de la reunión citada (Acta No. 6). ' +
-      'El miembro que llegue después de quince (15) minutos de la hora estipulada a las citaciones —reuniones o actividades de integración— deberá pagar una multa de diez mil pesos ($10.000 COP). La aplicación y control de esta multa estará a cargo del Comité de Convivencia.',
+      'El miembro que incurra en el atraso de tres (3) cuotas será expulsado del fondo. No obstante, durante el primer mes de atraso tendrá derecho, por una única vez, a un proceso de renegociación: en primera instancia con el Comité y, de ser necesario, en segunda instancia con la Junta. Si no se logra un acuerdo en ninguna de estas instancias, el miembro será expulsado del fondo.',
   },
   {
-    id: 'actividades-inversiones',
-    title: 'Artículo VII — Actividades e Inversiones',
-    summary: 'Comité de actividades e inversiones para ingresos adicionales.',
+    id: 'articulo-7',
+    title: 'Artículo 7 — Préstamos e interés',
+    summary: 'El fondo solo presta a sus miembros, con interés mínimo.',
     body:
-      'Habrá un comité de actividades cuyas condiciones se fijarán en la reunión de inicio de año, con el fin de generar ingresos adicionales y promover la integración de los miembros. Un caso especial de no participación será discutido por la Junta. ' +
-      'Asimismo, el fondo realizará inversiones rentables cuyas condiciones serán definidas en la reunión de inicio de año y sometidas a votación, con el fin de generar ingresos adicionales.',
+      'El dinero del fondo solo y únicamente se puede prestar a sus miembros, con un interés no menor al dos por ciento (2%).',
   },
   {
-    id: 'junta',
-    title: 'Artículo VIII — Junta Directiva',
-    summary: 'Requisitos de antigüedad y criterios de elección.',
+    id: 'articulo-8',
+    title: 'Artículo 8 — Préstamos sin fiador',
+    summary: 'Límite sin fiador y requisito de codeudor.',
     body:
-      'La Junta será elegida entre los miembros con una antigüedad de tres (3) años o más, considerando criterios personales específicos como su continuidad, el pago a tiempo de sus obligaciones y su buen comportamiento personal y crediticio.',
+      'El límite de dinero que se presta sin fiador es de quinientos mil pesos m/cte ($500.000) o el 80% del valor ahorrado hasta el momento en que se está solicitando el crédito. Para valores superiores se requiere un fiador perteneciente al fondo, y que la capacidad de ambos alcance para cubrir el valor del préstamo.',
   },
   {
-    id: 'retiros',
-    title: 'Artículo IX — Retiro de Miembros Antiguos',
+    id: 'articulo-9',
+    title: 'Artículo 9 — Mora en el pago de créditos',
+    summary: 'Descuento automático de ahorros del deudor o codeudor.',
+    body:
+      'Sobre el pago de los créditos, si el deudor queda en mora por 2 meses, automáticamente se le descuenta el valor en mora de los ahorros que tenga en el fondo; y en dado caso que al deudor no le alcancen sus ahorros para pagar el crédito o lo que tenga en mora, automáticamente se les descontará a los ahorros del codeudor.',
+  },
+  {
+    id: 'articulo-10',
+    title: 'Artículo 10 — Utilidades por préstamos',
+    summary: 'Reparto de utilidades y pérdida del derecho por incumplimiento.',
+    body:
+      'Las utilidades por préstamos serán divididas porcentualmente de acuerdo al saldo que tenga al cierre del año actual, siempre y cuando cumpla con la cuota de ahorro mensual máximo hasta el 15 del mes vigente, sujeto a lo establecido en el ítem 5 del presente estatuto. A la primera oportunidad en que se halle el incumplimiento del ahorro mensual en la fecha estipulada, automáticamente perderá todo derecho a dichas utilidades.',
+  },
+  {
+    id: 'articulo-11',
+    title: 'Artículo 11 — Cierre de año',
+    summary: 'Devolución de aportes y base que queda en el fondo.',
+    body:
+      'Al final del año se devolverán los aportes, dejando todos los miembros una base de 350 mil de lo ahorrado. Las personas antiguas que se retiran pierden cualquier beneficio de antigüedad, adaptándose a los estatutos vigentes a su reingreso.',
+  },
+  {
+    id: 'articulo-12',
+    title: 'Artículo 12 — Comité de actividades',
+    summary: 'Actividades para integración e ingresos adicionales.',
+    body:
+      'Habrá comité de actividades cuyas condiciones se fijarán en la reunión de inicio de año, con el fin de generar ingresos adicionales. Es importante reiterar que el fin de las actividades es la integración de los miembros, más que las utilidades del mismo. Cabe resaltar que, habiendo un caso especial de no participación, será discutido por la junta.',
+  },
+  {
+    id: 'articulo-13',
+    title: 'Artículo 13 — Sanción por inasistencia y poderes',
+    summary: 'Multa por inasistencia a reuniones y régimen de poderes.',
+    body:
+      'El valor de la sanción por inasistencia a las reuniones es de treinta mil pesos ($30.000). Se autoriza un máximo de dos (2) poderes consecutivos de un mismo usuario y un máximo de tres (3) poderes por usuario en un año calendario. Los poderes se deben hacer llegar a la presidencia del fondo con un plazo no menor a seis (6) horas previas al inicio de la reunión citada (Acta No. 6). Este valor será descontado de los ahorros.',
+  },
+  {
+    id: 'articulo-14',
+    title: 'Artículo 14 — Retiro de asociados antiguos',
     summary: 'Devolución de dineros a asociados antiguos a 2022.',
     body:
-      'A los asociados antiguos a 2022 que se retiren no se les retendrá ningún dinero de aportes ni de ahorros: se les devolverá todo el dinero que hayan allegado al fondo. ' +
-      'Sin embargo, si el retiro ocurre en un mes diferente a diciembre, el miembro perderá el derecho a recibir utilidades por los préstamos y las actividades realizadas en el año calendario (Acta No. 9). ' +
-      'Se exceptúa la entrega del dinero de la admisión para los nuevos integrantes que ingresan a partir de 2023.',
+      'A los asociados antiguos a 2022 que se retiren no se les retendrá ningún dinero de aportes ni de ahorros; se les devolverá todo el dinero que hayan allegado al fondo. Sin embargo, si se retira en un mes diferente al mes de diciembre, perderá el derecho a recibir utilidades por los préstamos y las actividades realizadas en el año calendario (Acta No. 9). Se exceptúa la entrega del dinero de la admisión para los nuevos integrantes que ingresan a partir del 2023.',
+  },
+  {
+    id: 'articulo-15',
+    title: 'Artículo 15 — Valor del ahorro mensual',
+    summary: 'Definición e inmutabilidad del valor durante el año.',
+    body:
+      'Al ingresar al fondo, el valor del ahorro mensual quedará definido con la realización del primer pago de ahorro. Dicho valor será el monto que el miembro se compromete a ahorrar mensualmente y no podrá ser modificado durante el año en curso, sujeto a lo establecido en el ítem 6 del presente estatuto.',
+  },
+  {
+    id: 'articulo-16',
+    title: 'Artículo 16 — Elección de la Junta',
+    summary: 'Antigüedad y criterios para integrar la Junta.',
+    body:
+      'La junta será elegida con miembros a partir de 3 años de antigüedad, con criterios personales específicos como su continuidad, pagos a tiempo y buen comportamiento personal y crediticio.',
+  },
+  {
+    id: 'articulo-17',
+    title: 'Artículo 17 — Sanción por llegada tarde',
+    summary: 'Multa por llegar tarde a las citaciones.',
+    body:
+      'El miembro que llegue después de quince (15) minutos de la hora estipulada a las citaciones, ya sean reuniones o actividades de integración del fondo de ahorros familiar, deberá pagar una multa de diez mil pesos ($10.000). La aplicación y control de esta multa estará a cargo del Comité de Convivencia.',
+  },
+  {
+    id: 'articulo-18',
+    title: 'Artículo 18 — Inversiones del fondo',
+    summary: 'Inversiones rentables aprobadas por votación.',
+    body:
+      'El fondo realizará inversiones rentables cuyas condiciones serán definidas en la reunión de inicio de año, con el fin de generar ingresos adicionales, las cuales serán sometidas a votación.',
   },
 ]
 
-const openId = ref<string | null>('ingreso')
+const openId = ref<string | null>('articulo-1')
 
 function toggle(id: string) {
   openId.value = openId.value === id ? null : id

--- a/app/pages/prestamos/solicitar.vue
+++ b/app/pages/prestamos/solicitar.vue
@@ -12,6 +12,7 @@ definePageMeta({
 const supabase = useSupabase()
 const router = useRouter()
 const toast = useToast()
+const { settings: fundSettings, load: loadFundSettings } = useFundSettings()
 
 const totalSavings = ref(0)
 const members = ref<ProfileOption[]>([])
@@ -37,6 +38,7 @@ onMounted(async () => {
       .from('profiles')
       .select('id, full_name')
       .neq('id', user.id),
+    loadFundSettings(),
   ])
 
   totalSavings.value = savingsResult.data
@@ -44,17 +46,21 @@ onMounted(async () => {
     : 0
 
   members.value = (membersResult.data as ProfileOption[]) ?? []
+  interestRate.value = fundSettings.value?.min_interest_rate ?? 2
   loading.value = false
 })
 
 const maxWithoutGuarantor = computed(() => {
-  const eightyPercent = Math.floor(totalSavings.value * 0.8)
-  return Math.min(200000, eightyPercent)
+  if (!fundSettings.value) return 0
+  const savingsCap = Math.floor(
+    totalSavings.value * (fundSettings.value.loan_savings_percentage_cap / 100),
+  )
+  return Math.min(fundSettings.value.loan_limit_without_guarantor, savingsCap)
 })
 
 const requiresGuarantor = computed(() => {
   if (!requestedAmount.value) return false
-  return requestedAmount.value > 200000 || requestedAmount.value > totalSavings.value * 0.8
+  return requestedAmount.value > maxWithoutGuarantor.value
 })
 
 const totalDue = computed(() => {
@@ -72,7 +78,7 @@ function formatCOP(value: number): string {
 
 async function handleSubmit() {
   if (!requestedAmount.value || requestedAmount.value <= 0) return
-  if (interestRate.value < 2) return
+  if (interestRate.value < (fundSettings.value?.min_interest_rate ?? 2)) return
   if (!installments.value || installments.value < 1) return
   if (requiresGuarantor.value && !guarantorId.value) return
 
@@ -162,11 +168,13 @@ async function handleSubmit() {
             v-model.number="interestRate"
             type="number"
             required
-            min="2"
+            :min="fundSettings?.min_interest_rate ?? 2"
             step="0.5"
             class="w-full rounded-lg border border-gray-700 bg-gray-800 px-4 py-2.5 text-white placeholder-gray-500 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 outline-none transition"
           />
-          <p class="text-xs text-gray-500 mt-1">Mínimo 2% según estatutos.</p>
+          <p class="text-xs text-gray-500 mt-1">
+            Mínimo {{ fundSettings?.min_interest_rate ?? 2 }}% según estatutos.
+          </p>
         </div>
 
         <!-- Cuotas -->

--- a/app/utils/activityReport.ts
+++ b/app/utils/activityReport.ts
@@ -1,0 +1,382 @@
+// ============================================================
+// FODAF — Generación del reporte PDF de una actividad cerrada
+// ============================================================
+// Construido con jsPDF + jspdf-autotable. Una sola página A4 si
+// hay pocas filas, paginado automático si hay muchas (autoTable
+// se encarga de cortar tablas entre páginas).
+//
+// El reporte se exporta desde el detalle de la actividad cuando
+// está en estado `finished` y el usuario es admin o miembro del
+// comité — ver `canExport` en `/actividades/[id].vue`.
+// ============================================================
+
+import { jsPDF } from 'jspdf'
+import autoTable from 'jspdf-autotable'
+
+// ---- Tipos del payload ----
+
+export interface ActivityReportData {
+  activity: {
+    name: string
+    activity_date: string
+    start_at: string | null
+    finished_at: string | null
+    team_name: string | null
+  }
+  expenses: {
+    description: string
+    amount: number
+  }[]
+  products: {
+    name: string
+    cost_price: number
+    selling_price: number
+    stock_quantity: number
+    sold: number
+    available: number
+  }[]
+  sales: {
+    product_name: string
+    quantity: number
+    buyer_label: string
+    seller_label: string
+    total_price: number
+  }[]
+}
+
+// ---- Paleta (espejo del CSS de la app, fondo blanco para impresión) ----
+const COLORS = {
+  emerald: [5, 150, 105] as const,
+  emeraldLight: [209, 250, 229] as const,
+  gray900: [17, 24, 39] as const,
+  gray700: [55, 65, 81] as const,
+  gray500: [107, 114, 128] as const,
+  gray300: [209, 213, 219] as const,
+  gray100: [243, 244, 246] as const,
+  red: [220, 38, 38] as const,
+  blue: [37, 99, 235] as const,
+}
+
+const PAGE_MARGIN = 40
+
+/**
+ * Construye y descarga el reporte PDF de la actividad. El
+ * nombre del archivo se deriva del nombre de la actividad.
+ */
+export function exportActivityReportPdf(data: ActivityReportData): void {
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'a4' })
+  const pageWidth = doc.internal.pageSize.getWidth()
+
+  drawHeader(doc, data, pageWidth)
+  let cursorY = drawMetadata(doc, data, pageWidth, 130)
+  cursorY = drawFinancialSummary(doc, data, pageWidth, cursorY + 16)
+  cursorY = drawExpensesTable(doc, data, cursorY + 24)
+  cursorY = drawInventoryTable(doc, data, cursorY + 16)
+  cursorY = drawSalesTable(doc, data, cursorY + 16)
+  drawFooter(doc, pageWidth)
+
+  const filename = `FODAF-${slugify(data.activity.name)}.pdf`
+
+  // Abrimos el PDF en una nueva pestaña en vez de forzar
+  // descarga. Razón: Chrome Safe Browsing marca como sospechosas
+  // las descargas que vienen de hostnames HTTP no-localhost
+  // (ej. `fodaf.development`), las deja como `.crdownload` y
+  // les pone nombre aleatorio. Mostrando el PDF en el visor del
+  // navegador el usuario lo guarda con Ctrl+S o el ícono del
+  // visor, evitando esa heurística.
+  const blob = doc.output('blob')
+  const url = URL.createObjectURL(blob)
+
+  // Le damos un nombre al recurso vía hash (algunos visores lo
+  // usan al sugerir el nombre del archivo en "Guardar como").
+  const win = window.open(`${url}#${encodeURIComponent(filename)}`, '_blank', 'noopener')
+  if (!win) {
+    // Pop-up bloqueado: caemos a descarga directa con anchor.
+    const link = document.createElement('a')
+    link.href = url
+    link.download = filename
+    link.rel = 'noopener'
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
+
+  // Liberamos la URL del Blob después de que el visor / descarga
+  // haya tenido tiempo de leer el contenido.
+  setTimeout(() => URL.revokeObjectURL(url), 30_000)
+}
+
+// ---- Cabecera: banner emerald con título y nombre de actividad ----
+function drawHeader(doc: jsPDF, data: ActivityReportData, pageWidth: number) {
+  doc.setFillColor(...COLORS.emerald)
+  doc.rect(0, 0, pageWidth, 100, 'F')
+
+  doc.setTextColor(255, 255, 255)
+  doc.setFont('helvetica', 'normal')
+  doc.setFontSize(10)
+  doc.text('FODAF · Fondo de Ahorro Familiar', PAGE_MARGIN, 32)
+
+  doc.setFont('helvetica', 'bold')
+  doc.setFontSize(20)
+  doc.text('Reporte de Actividad', PAGE_MARGIN, 56)
+
+  doc.setFont('helvetica', 'normal')
+  doc.setFontSize(13)
+  const name = truncate(doc, data.activity.name, pageWidth - PAGE_MARGIN * 2)
+  doc.text(name, PAGE_MARGIN, 80)
+}
+
+// ---- Metadatos: fecha de inicio, comité, fecha de cierre ----
+function drawMetadata(doc: jsPDF, data: ActivityReportData, pageWidth: number, y: number): number {
+  doc.setTextColor(...COLORS.gray700)
+  doc.setFontSize(10)
+
+  const startLabel = data.activity.start_at
+    ? formatDatetimeLocal(data.activity.start_at)
+    : formatDateLocal(data.activity.activity_date)
+
+  const lines: { label: string; value: string }[] = [
+    { label: 'Fecha del evento', value: startLabel },
+    { label: 'Comité responsable', value: data.activity.team_name ?? 'Sin comité' },
+  ]
+  if (data.activity.finished_at) {
+    lines.push({ label: 'Cerrada el', value: formatDatetimeLocal(data.activity.finished_at) })
+  }
+
+  for (const line of lines) {
+    doc.setFont('helvetica', 'bold')
+    doc.text(`${line.label}:`, PAGE_MARGIN, y)
+    doc.setFont('helvetica', 'normal')
+    doc.text(line.value, PAGE_MARGIN + 110, y)
+    y += 16
+  }
+
+  return y
+}
+
+// ---- Resumen financiero: 3 cards horizontales ----
+function drawFinancialSummary(doc: jsPDF, data: ActivityReportData, pageWidth: number, y: number): number {
+  const totalExpenses = data.expenses.reduce((s, e) => s + e.amount, 0)
+  const inventoryCost = data.products.reduce((s, p) => s + p.cost_price * p.stock_quantity, 0)
+  const totalCosts = totalExpenses + inventoryCost
+  const grossIncome = data.sales.reduce((s, sale) => s + sale.total_price, 0)
+  const netProfit = grossIncome - totalCosts
+
+  const cardW = (pageWidth - PAGE_MARGIN * 2 - 16) / 3
+  const cardH = 70
+  const x0 = PAGE_MARGIN
+  const x1 = x0 + cardW + 8
+  const x2 = x1 + cardW + 8
+
+  drawSummaryCard(doc, x0, y, cardW, cardH, 'Costos Totales', formatCOPLocal(totalCosts), COLORS.gray900)
+  drawSummaryCard(doc, x1, y, cardW, cardH, 'Ingresos Brutos', formatCOPLocal(grossIncome), COLORS.blue)
+  drawSummaryCard(
+    doc, x2, y, cardW, cardH,
+    'Ganancia Neta',
+    formatCOPLocal(netProfit),
+    netProfit >= 0 ? COLORS.emerald : COLORS.red,
+  )
+
+  // Sub-línea con desglose de costos
+  doc.setFontSize(8)
+  doc.setTextColor(...COLORS.gray500)
+  doc.text(
+    `Desglose de costos: gastos ${formatCOPLocal(totalExpenses)} · inventario ${formatCOPLocal(inventoryCost)}`,
+    PAGE_MARGIN, y + cardH + 14,
+  )
+
+  return y + cardH + 14
+}
+
+function drawSummaryCard(
+  doc: jsPDF, x: number, y: number, w: number, h: number,
+  label: string, value: string, valueColor: readonly [number, number, number],
+) {
+  doc.setDrawColor(...COLORS.gray300)
+  doc.setFillColor(...COLORS.gray100)
+  doc.roundedRect(x, y, w, h, 6, 6, 'FD')
+
+  doc.setFont('helvetica', 'normal')
+  doc.setFontSize(8)
+  doc.setTextColor(...COLORS.gray500)
+  doc.text(label.toUpperCase(), x + 12, y + 18)
+
+  doc.setFont('helvetica', 'bold')
+  doc.setFontSize(15)
+  doc.setTextColor(...valueColor)
+  doc.text(value, x + 12, y + 44)
+}
+
+// ---- Tabla de gastos ----
+function drawExpensesTable(doc: jsPDF, data: ActivityReportData, y: number): number {
+  drawSectionTitle(doc, `Gastos Generales (${data.expenses.length})`, y)
+  const startY = y + 16
+
+  if (data.expenses.length === 0) {
+    drawEmptyRow(doc, 'No se registraron gastos.', startY)
+    return startY + 24
+  }
+
+  autoTable(doc, {
+    startY,
+    head: [['Descripción', 'Monto']],
+    body: data.expenses.map(e => [e.description, formatCOPLocal(e.amount)]),
+    ...tableStyles(),
+    columnStyles: {
+      1: { halign: 'right', cellWidth: 110 },
+    },
+  })
+  return (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY
+}
+
+// ---- Tabla de inventario ----
+function drawInventoryTable(doc: jsPDF, data: ActivityReportData, y: number): number {
+  drawSectionTitle(doc, `Inventario (${data.products.length})`, y)
+  const startY = y + 16
+
+  if (data.products.length === 0) {
+    drawEmptyRow(doc, 'No se registraron productos.', startY)
+    return startY + 24
+  }
+
+  autoTable(doc, {
+    startY,
+    head: [['Producto', 'Costo', 'Venta', 'Stock', 'Vendidas', 'Disponible']],
+    body: data.products.map(p => [
+      p.name,
+      formatCOPLocal(p.cost_price),
+      formatCOPLocal(p.selling_price),
+      String(p.stock_quantity),
+      String(p.sold),
+      String(p.available),
+    ]),
+    ...tableStyles(),
+    columnStyles: {
+      1: { halign: 'right' },
+      2: { halign: 'right' },
+      3: { halign: 'right' },
+      4: { halign: 'right' },
+      5: { halign: 'right' },
+    },
+  })
+  return (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY
+}
+
+// ---- Tabla de ventas ----
+function drawSalesTable(doc: jsPDF, data: ActivityReportData, y: number): number {
+  drawSectionTitle(doc, `Ventas Registradas (${data.sales.length})`, y)
+  const startY = y + 16
+
+  if (data.sales.length === 0) {
+    drawEmptyRow(doc, 'No se registraron ventas.', startY)
+    return startY + 24
+  }
+
+  autoTable(doc, {
+    startY,
+    head: [['Producto', 'Cant.', 'Comprador', 'Vendedor', 'Total']],
+    body: data.sales.map(s => [
+      s.product_name,
+      String(s.quantity),
+      s.buyer_label,
+      s.seller_label,
+      formatCOPLocal(s.total_price),
+    ]),
+    ...tableStyles(),
+    columnStyles: {
+      1: { halign: 'right', cellWidth: 40 },
+      4: { halign: 'right', cellWidth: 80 },
+    },
+  })
+  return (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY
+}
+
+// ---- Helpers de dibujo ----
+function drawSectionTitle(doc: jsPDF, text: string, y: number) {
+  doc.setFont('helvetica', 'bold')
+  doc.setFontSize(11)
+  doc.setTextColor(...COLORS.gray900)
+  doc.text(text, PAGE_MARGIN, y)
+}
+
+function drawEmptyRow(doc: jsPDF, text: string, y: number) {
+  doc.setFont('helvetica', 'italic')
+  doc.setFontSize(9)
+  doc.setTextColor(...COLORS.gray500)
+  doc.text(text, PAGE_MARGIN, y + 12)
+}
+
+function drawFooter(doc: jsPDF, pageWidth: number) {
+  const pageCount = doc.getNumberOfPages()
+  for (let i = 1; i <= pageCount; i++) {
+    doc.setPage(i)
+    const pageHeight = doc.internal.pageSize.getHeight()
+    doc.setFont('helvetica', 'normal')
+    doc.setFontSize(8)
+    doc.setTextColor(...COLORS.gray500)
+    doc.text(`Generado el ${formatDatetimeLocal(new Date().toISOString())}`, PAGE_MARGIN, pageHeight - 20)
+    doc.text(`Página ${i} de ${pageCount}`, pageWidth - PAGE_MARGIN, pageHeight - 20, { align: 'right' })
+  }
+}
+
+function tableStyles() {
+  return {
+    margin: { left: PAGE_MARGIN, right: PAGE_MARGIN },
+    styles: {
+      fontSize: 9,
+      cellPadding: 6,
+      textColor: COLORS.gray700 as unknown as number[],
+      lineColor: COLORS.gray300 as unknown as number[],
+      lineWidth: 0.5,
+    },
+    headStyles: {
+      fillColor: COLORS.emerald as unknown as number[],
+      textColor: [255, 255, 255] as number[],
+      fontStyle: 'bold' as const,
+    },
+    alternateRowStyles: {
+      fillColor: COLORS.gray100 as unknown as number[],
+    },
+  }
+}
+
+// ---- Locales (jsPDF no integra Intl.NumberFormat con tipografía) ----
+function formatCOPLocal(value: number): string {
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(value)
+}
+
+function formatDateLocal(dateStr: string): string {
+  const date = dateStr.length === 10 ? new Date(dateStr + 'T12:00:00') : new Date(dateStr)
+  return date.toLocaleDateString('es-CO', { day: 'numeric', month: 'long', year: 'numeric' })
+}
+
+function formatDatetimeLocal(isoStr: string): string {
+  return new Date(isoStr).toLocaleString('es-CO', {
+    day: 'numeric', month: 'long', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  })
+}
+
+// ---- Util de nombre de archivo ----
+function slugify(text: string): string {
+  return text
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'actividad'
+}
+
+// Trunca un texto para que quepa en un ancho máximo dentro del PDF.
+function truncate(doc: jsPDF, text: string, maxWidth: number): string {
+  if (doc.getTextWidth(text) <= maxWidth) return text
+  let truncated = text
+  while (truncated.length > 0 && doc.getTextWidth(truncated + '…') > maxWidth) {
+    truncated = truncated.slice(0, -1)
+  }
+  return truncated + '…'
+}

--- a/app/utils/format.ts
+++ b/app/utils/format.ts
@@ -28,3 +28,18 @@ export function formatDate(dateStr: string): string {
     year: 'numeric',
   })
 }
+
+/**
+ * Formatea fecha + hora en hora local Colombia. Para timestamptz
+ * (ej. `start_at` de actividades). Devuelve algo como
+ * "18 mayo de 2026, 03:00 p. m.".
+ */
+export function formatDatetime(isoStr: string): string {
+  return new Date(isoStr).toLocaleString('es-CO', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}

--- a/package.json
+++ b/package.json
@@ -11,11 +11,20 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.100.1",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.7",
     "nuxt": "^4.4.2",
     "vue": "^3.5.30",
     "vue-router": "^5.0.4"
   },
   "devDependencies": {
     "@nuxtjs/tailwindcss": "^6.14.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "core-js",
+      "esbuild"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.100.1
         version: 2.100.1
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
+      jspdf-autotable:
+        specifier: ^5.0.7
+        version: 5.0.7(jspdf@4.2.1)
       nuxt:
         specifier: ^4.4.2
         version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.31)(cac@6.7.14)(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(typescript@6.0.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(yaml@2.8.3)
@@ -135,6 +141,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -553,48 +563,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.117.0':
     resolution: {integrity: sha512-C3zapJconWpl2Y7LR3GkRkH6jxpuV2iVUfkFcHT5Ffn4Zu7l88mZa2dhcfdULZDybN1Phka/P34YUzuskUUrXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-ppc64-gnu@0.117.0':
     resolution: {integrity: sha512-2T/Bm+3/qTfuNS4gKSzL8qbiYk+ErHW2122CtDx+ilZAzvWcJ8IbqdZIbEWOlwwe03lESTxPwTBLFqVgQU2OeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.117.0':
     resolution: {integrity: sha512-MKLjpldYkeoB4T+yAi4aIAb0waifxUjLcKkCUDmYAY3RqBJTvWK34KtfaKZL0IBMIXfD92CbKkcxQirDUS9Xcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-musl@0.117.0':
     resolution: {integrity: sha512-UFVcbPvKUStry6JffriobBp8BHtjmLLPl4bCY+JMxIn/Q3pykCpZzRwFTcDurG/kY8tm+uSNfKKdRNa5Nh9A7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.117.0':
     resolution: {integrity: sha512-B9GyPQ1NKbvpETVAMyJMfRlD3c6UJ7kiuFUAlx9LTYiQL+YIyT6vpuRlq1zgsXxavZluVrfeJv6x0owV4KDx4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.117.0':
     resolution: {integrity: sha512-fXfhtr+WWBGNy4M5GjAF5vu/lpulR4Me34FjTyaK9nDrTZs7LM595UDsP1wliksqp4hD/KdoqHGmbCrC+6d4vA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.117.0':
     resolution: {integrity: sha512-jFBgGbx1oLadb83ntJmy1dWlAHSQanXTS21G4PgkxyONmxZdZ/UMKr7KsADzMuoPsd2YhJHxzRpwJd9U+4BFBw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-openharmony-arm64@0.117.0':
     resolution: {integrity: sha512-nxPd9vx1vYz8IlIMdl9HFdOK/ood1H5hzbSFsyO8JU55tkcJoBL8TLCbuFf9pHpOy27l2gcPyV6z3p4eAcTH5Q==}
@@ -672,48 +690,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.117.0':
     resolution: {integrity: sha512-QagKTDF4lrz8bCXbUi39Uq5xs7C7itAseKm51f33U+Dyar9eJY/zGKqfME9mKLOiahX7Fc1J3xMWVS0AdDXLPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.117.0':
     resolution: {integrity: sha512-RPddpcE/0xxWaommWy0c5i/JdrXcXAkxBS2GOrAUh5LKmyCh03hpJedOAWszG4ADsKQwoUQQ1/tZVGRhZIWtKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.117.0':
     resolution: {integrity: sha512-ur/WVZF9FSOiZGxyP+nfxZzuv6r5OJDYoVxJnUR7fM/hhXLh4V/be6rjbzm9KLCDBRwYCEKJtt+XXNccwd06IA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.117.0':
     resolution: {integrity: sha512-ujGcAx8xAMvhy7X5sBFi3GXML1EtyORuJZ5z2T6UV3U416WgDX/4OCi3GnoteeenvxIf6JgP45B+YTHpt71vpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.117.0':
     resolution: {integrity: sha512-hbsfKjUwRjcMZZvvmpZSc+qS0bHcHRu8aV/I3Ikn9BzOA0ZAgUE7ctPtce5zCU7bM8dnTLi4sJ1Pi9YHdx6Urw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.117.0':
     resolution: {integrity: sha512-1QrTrf8rige7UPJrYuDKJLQOuJlgkt+nRSJLBMHWNm9TdivzP48HaK3f4q18EjNlglKtn03lgjMu4fryDm8X4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.117.0':
     resolution: {integrity: sha512-gRvK6HPzF5ITRL68fqb2WYYs/hGviPIbkV84HWCgiJX+LkaOpp+HIHQl3zVZdyKHwopXToTbXbtx/oFjDjl8pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.117.0':
     resolution: {integrity: sha512-QPJvFbnnDZZY7xc+xpbIBWLThcGBakwaYA9vKV8b3+oS5MGfAZUoTFJcix5+Zg2Ri46sOfrUim6Y6jsKNcssAQ==}
@@ -794,48 +820,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.117.0':
     resolution: {integrity: sha512-ykxpPQp0eAcSmhy0Y3qKvdanHY4d8THPonDfmCoktUXb6r0X6qnjpJB3V+taN1wevW55bOEZd97kxtjTKjqhmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-ppc64-gnu@0.117.0':
     resolution: {integrity: sha512-Rvspti4Kr7eq6zSrURK5WjscfWQPvmy/KjJZV45neRKW8RLonE3r9+NgrwSLGoHvQ3F24fbqlkplox1RtlhH5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.117.0':
     resolution: {integrity: sha512-Dr2ZW9ZZ4l1eQ5JUEUY3smBh4JFPCPuybWaDZTLn3ADZjyd8ZtNXEjeMT8rQbbhbgSL9hEgbwaqraole3FNThQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-musl@0.117.0':
     resolution: {integrity: sha512-oD1Bnes1bIC3LVBSrWEoSUBj6fvatESPwAVWfJVGVQlqWuOs/ZBn1e4Nmbipo3KGPHK7DJY75r/j7CQCxhrOFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.117.0':
     resolution: {integrity: sha512-qT//IAPLvse844t99Kff5j055qEbXfwzWgvCMb0FyjisnB8foy25iHZxZIocNBe6qwrCYWUP1M8rNrB/WyfS1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.117.0':
     resolution: {integrity: sha512-2YEO5X+KgNzFqRVO5dAkhjcI5gwxus4NSWVl/+cs2sI6P0MNPjqE3VWPawl4RTC11LvetiiZdHcujUCPM8aaUw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.117.0':
     resolution: {integrity: sha512-3wqWbTSaIFZvDr1aqmTul4cg8PRWYh6VC52E8bLI7ytgS/BwJLW+sDUU2YaGIds4sAf/1yKeJRmudRCDPW9INg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-openharmony-arm64@0.117.0':
     resolution: {integrity: sha512-Ebxx6NPqhzlrjvx4+PdSqbOq+li0f7X59XtJljDghkbJsbnkHvhLmPR09ifHt5X32UlZN63ekjwcg/nbmHLLlA==}
@@ -895,36 +929,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.6':
     resolution: {integrity: sha512-byAiBZ1t3tXQvc8dMD/eoyE7lTXYorhn+6uVW5AC+JGI1KtJC/LvDche5cfUE+qiefH+Ybq0bUCJU0aB1cSHUA==}
@@ -1082,66 +1122,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -1220,8 +1273,17 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
+
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1463,6 +1525,10 @@ packages:
   bare-url@2.4.0:
     resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1553,6 +1619,10 @@ packages:
 
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
+
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1669,6 +1739,9 @@ packages:
     resolution: {integrity: sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==}
     engines: {node: '>= 0.8'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -1697,6 +1770,9 @@ packages:
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -1854,6 +1930,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  dompurify@3.4.3:
+    resolution: {integrity: sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -1982,6 +2061,9 @@ packages:
     resolution: {integrity: sha512-XXyd9d3ie/JeIIjm6WeKalvapGGFI4ShAjPJM78vgUFYzoEsuNSjvvVTuht0XZcwbVdOnEEGzhxwguRbxkIcDg==}
     hasBin: true
 
+  fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1993,6 +2075,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -2142,6 +2227,10 @@ packages:
   hookable@6.1.0:
     resolution: {integrity: sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==}
 
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+
   http-assert@1.5.0:
     resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
     engines: {node: '>= 0.8'}
@@ -2203,6 +2292,9 @@ packages:
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
@@ -2335,6 +2427,14 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jspdf-autotable@5.0.7:
+    resolution: {integrity: sha512-2wr7H6liNDBYNwt25hMQwXkEWFOEopgKIvR1Eukuw6Zmprm/ZcnmLTQEjW7Xx3FCbD3v7pflLcnMAv/h1jFDQw==}
+    peerDependencies:
+      jspdf: ^2 || ^3 || ^4
+
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
 
   keygrip@1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
@@ -2685,6 +2785,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2723,6 +2826,9 @@ packages:
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2996,6 +3102,9 @@ packages:
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -3039,6 +3148,9 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
@@ -3068,6 +3180,10 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   rollup-plugin-visualizer@7.0.1:
     resolution: {integrity: sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==}
@@ -3202,6 +3318,10 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
@@ -3281,6 +3401,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -3323,6 +3447,9 @@ packages:
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -3523,6 +3650,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -3915,6 +4045,8 @@ snapshots:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -4949,7 +5081,15 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/pako@2.0.4': {}
+
+  '@types/raf@3.4.3':
+    optional: true
+
   '@types/resolve@1.20.2': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/ws@8.18.1':
     dependencies:
@@ -5237,6 +5377,9 @@ snapshots:
     dependencies:
       bare-path: 3.0.0
 
+  base64-arraybuffer@1.0.2:
+    optional: true
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.11: {}
@@ -5335,6 +5478,18 @@ snapshots:
       lodash.uniq: 4.5.0
 
   caniuse-lite@1.0.30001781: {}
+
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/raf': 3.4.3
+      core-js: 3.49.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
 
   chalk@4.1.2:
     dependencies:
@@ -5444,6 +5599,9 @@ snapshots:
       depd: 2.0.0
       keygrip: 1.1.0
 
+  core-js@3.49.0:
+    optional: true
+
   core-util-is@1.0.3: {}
 
   crc-32@1.2.2: {}
@@ -5468,6 +5626,11 @@ snapshots:
   css-declaration-sorter@7.3.1(postcss@8.5.8):
     dependencies:
       postcss: 8.5.8
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   css-select@5.2.2:
     dependencies:
@@ -5599,6 +5762,11 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+    optional: true
 
   domutils@3.2.2:
     dependencies:
@@ -5733,6 +5901,12 @@ snapshots:
 
   fast-npm-meta@1.4.2: {}
 
+  fast-png@6.4.0:
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.1.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -5740,6 +5914,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.2: {}
 
   file-uri-to-path@1.0.0: {}
 
@@ -5898,6 +6074,12 @@ snapshots:
 
   hookable@6.1.0: {}
 
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    optional: true
+
   http-assert@1.5.0:
     dependencies:
       deep-equal: 1.0.1
@@ -5965,6 +6147,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@4.1.1: {}
+
+  iobuffer@5.4.0: {}
 
   ioredis@5.10.1:
     dependencies:
@@ -6083,6 +6267,21 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jspdf-autotable@5.0.7(jspdf@4.2.1):
+    dependencies:
+      jspdf: 4.2.1
+
+  jspdf@4.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      fast-png: 6.4.0
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.49.0
+      dompurify: 3.4.3
+      html2canvas: 1.4.1
 
   keygrip@1.1.0:
     dependencies:
@@ -6715,6 +6914,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@2.1.0: {}
+
   parseurl@1.3.3: {}
 
   path-is-absolute@1.0.1: {}
@@ -6742,6 +6943,9 @@ snapshots:
   pathe@2.0.3: {}
 
   perfect-debounce@2.1.0: {}
+
+  performance-now@2.1.0:
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -6985,6 +7189,11 @@ snapshots:
 
   radix3@1.1.2: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   range-parser@1.2.1: {}
 
   rc9@2.1.2:
@@ -7037,6 +7246,9 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   regexp-tree@0.1.27: {}
 
   replace-in-file@6.3.5:
@@ -7061,6 +7273,9 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   rollup-plugin-visualizer@7.0.1(rollup@4.60.0):
     dependencies:
@@ -7208,6 +7423,9 @@ snapshots:
 
   srvx@0.11.13: {}
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   standard-as-callback@2.1.0: {}
 
   statuses@1.5.0: {}
@@ -7292,6 +7510,9 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svg-pathdata@6.0.3:
+    optional: true
 
   svgo@4.0.1:
     dependencies:
@@ -7387,6 +7608,11 @@ snapshots:
       b4a: 1.8.0
     transitivePeerDependencies:
       - react-native-b4a
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   thenify-all@1.6.0:
     dependencies:
@@ -7551,6 +7777,11 @@ snapshots:
   uqr@0.1.2: {}
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    optional: true
 
   vary@1.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: true
+  esbuild: true

--- a/supabase/migrations/20260514000000_add_fund_settings.sql
+++ b/supabase/migrations/20260514000000_add_fund_settings.sql
@@ -1,0 +1,105 @@
+-- ============================================================
+-- FODAF — Migración: tabla fund_settings (parámetros anuales del fondo)
+-- ============================================================
+-- Centraliza los valores que cambian de año a año según los
+-- estatutos (cuotas, bases, límites, multas, etc.).
+--
+-- Una fila por año (PK = year) para preservar la integridad
+-- histórica: una liquidación de 2025 debe calcularse con los
+-- parámetros de 2025, no con los vigentes hoy.
+-- ============================================================
+
+create table fund_settings (
+  year integer primary key check (year >= 2020),
+
+  -- Ingreso y admisión
+  admission_fee numeric not null check (admission_fee >= 0),
+  reentry_multiplier numeric not null default 2 check (reentry_multiplier >= 1),
+  enrollment_deadline_day integer not null check (enrollment_deadline_day between 1 and 31),
+  admission_exemption_year integer not null,
+  legacy_member_cutoff_year integer not null,
+
+  -- Ahorros
+  min_savings_minor numeric not null check (min_savings_minor >= 0),
+  min_savings_adult numeric not null check (min_savings_adult >= 0),
+  payment_deadline_day_january integer not null check (payment_deadline_day_january between 1 and 31),
+  payment_deadline_day_regular integer not null check (payment_deadline_day_regular between 1 and 31),
+
+  -- Moras y sanciones
+  missed_installments_for_expulsion integer not null check (missed_installments_for_expulsion > 0),
+  loan_default_months_for_deduction integer not null check (loan_default_months_for_deduction > 0),
+  penalty_absence numeric not null check (penalty_absence >= 0),
+  penalty_late_arrival numeric not null check (penalty_late_arrival >= 0),
+
+  -- Préstamos
+  min_interest_rate numeric not null check (min_interest_rate >= 0),
+  loan_limit_without_guarantor numeric not null check (loan_limit_without_guarantor >= 0),
+  loan_savings_percentage_cap numeric not null check (loan_savings_percentage_cap between 0 and 100),
+
+  -- Cierre anual y junta
+  year_end_base numeric not null check (year_end_base >= 0),
+  board_min_seniority_years integer not null check (board_min_seniority_years >= 0),
+
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- ------------------------------------------------------------
+-- Trigger: mantiene updated_at al día en cada modificación.
+-- ------------------------------------------------------------
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := timezone('utc'::text, now());
+  return new;
+end;
+$$;
+
+create trigger fund_settings_set_updated_at
+  before update on fund_settings
+  for each row execute function public.set_updated_at();
+
+-- ------------------------------------------------------------
+-- Parámetros vigentes 2026 (estatutos modificados en enero 2026).
+-- Se insertan dentro de la migración —no en seed.sql— para que
+-- producción también reciba la fila inicial.
+-- ------------------------------------------------------------
+insert into fund_settings (
+  year,
+  admission_fee, reentry_multiplier, enrollment_deadline_day,
+  admission_exemption_year, legacy_member_cutoff_year,
+  min_savings_minor, min_savings_adult,
+  payment_deadline_day_january, payment_deadline_day_regular,
+  missed_installments_for_expulsion, loan_default_months_for_deduction,
+  penalty_absence, penalty_late_arrival,
+  min_interest_rate, loan_limit_without_guarantor, loan_savings_percentage_cap,
+  year_end_base, board_min_seniority_years
+) values (
+  2026,
+  80000, 2, 31,
+  2023, 2022,
+  100000, 120000,
+  30, 15,
+  3, 2,
+  30000, 10000,
+  2, 500000, 80,
+  350000, 3
+);
+
+-- ------------------------------------------------------------
+-- RLS: lectura para cualquier autenticado; escritura solo admin.
+-- A diferencia del resto de tablas, el INSERT también es solo
+-- admin: crear la configuración de un año es una acción de gestión.
+-- ------------------------------------------------------------
+alter table fund_settings enable row level security;
+
+create policy "fund_settings_select_auth" on fund_settings
+  for select to authenticated using (true);
+create policy "fund_settings_insert_admin" on fund_settings
+  for insert to authenticated with check (public.is_admin());
+create policy "fund_settings_update_admin" on fund_settings
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "fund_settings_delete_admin" on fund_settings
+  for delete to authenticated using (public.is_admin());

--- a/supabase/migrations/20260514010000_drop_unused_fund_settings_columns.sql
+++ b/supabase/migrations/20260514010000_drop_unused_fund_settings_columns.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- FODAF — Migración: eliminar columnas no usadas de fund_settings
+-- ============================================================
+-- Se eliminan los parámetros que quedaron almacenados pero que
+-- ningún módulo del código consume todavía: no hay lógica de
+-- admisión, plazos de pago, expulsión por mora, descuento
+-- automático de préstamos ni antigüedad de Junta implementada.
+--
+-- Solo se conservan los parámetros que sí manejan condicionales
+-- o cálculos en la app (cuotas mínimas, multas, condiciones de
+-- préstamo y base de fin de año).
+-- ============================================================
+
+alter table fund_settings
+  drop column admission_fee,
+  drop column reentry_multiplier,
+  drop column enrollment_deadline_day,
+  drop column admission_exemption_year,
+  drop column legacy_member_cutoff_year,
+  drop column payment_deadline_day_january,
+  drop column payment_deadline_day_regular,
+  drop column missed_installments_for_expulsion,
+  drop column loan_default_months_for_deduction,
+  drop column board_min_seniority_years;

--- a/supabase/migrations/20260514020000_add_activity_pos.sql
+++ b/supabase/migrations/20260514020000_add_activity_pos.sql
@@ -1,0 +1,137 @@
+-- ============================================================
+-- FODAF — Migración: Punto de Venta (POS) e Inventario de actividades
+-- ============================================================
+-- Reestructura el módulo de Actividades:
+--   * Los totales financieros dejan de almacenarse manualmente en
+--     `activities` (columnas `costs` y `net_profits`). Ahora se
+--     derivan en tiempo real de gastos, inventario y ventas.
+--   * `activity_expenses` — gastos generales del evento.
+--   * `activity_products` — inventario de productos para el POS.
+--   * `activity_sales`    — ventas registradas por los miembros.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. activities: eliminar los totales manuales (única fuente de
+--    la verdad = expenses + products + sales).
+-- ------------------------------------------------------------
+alter table activities drop column costs;
+alter table activities drop column net_profits;
+
+-- ------------------------------------------------------------
+-- 2. activity_expenses — gastos generales (ej. alquiler de sillas)
+-- ------------------------------------------------------------
+create table activity_expenses (
+  id uuid default gen_random_uuid() primary key,
+  activity_id uuid not null references activities(id) on delete cascade,
+  description text not null,
+  amount numeric not null check (amount > 0),
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+create index activity_expenses_activity_id_idx on activity_expenses(activity_id);
+
+-- ------------------------------------------------------------
+-- 3. activity_products — inventario del evento
+--    stock_quantity = cantidad física comprada/disponible.
+-- ------------------------------------------------------------
+create table activity_products (
+  id uuid default gen_random_uuid() primary key,
+  activity_id uuid not null references activities(id) on delete cascade,
+  name text not null,
+  cost_price numeric not null check (cost_price >= 0),
+  selling_price numeric not null check (selling_price >= 0),
+  stock_quantity integer not null check (stock_quantity >= 0),
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+create index activity_products_activity_id_idx on activity_products(activity_id);
+
+-- ------------------------------------------------------------
+-- 4. activity_sales — ventas registradas desde el POS
+--    total_price lo calcula un trigger a partir del precio de
+--    venta del producto en el momento de la venta.
+-- ------------------------------------------------------------
+create table activity_sales (
+  id uuid default gen_random_uuid() primary key,
+  activity_id uuid not null references activities(id) on delete cascade,
+  seller_id uuid not null references profiles(id),
+  buyer_name text,
+  product_id uuid not null references activity_products(id) on delete cascade,
+  quantity integer not null check (quantity > 0),
+  total_price numeric not null default 0,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+create index activity_sales_activity_id_idx on activity_sales(activity_id);
+create index activity_sales_product_id_idx on activity_sales(product_id);
+
+-- Trigger: total_price = quantity * selling_price del producto.
+-- Garantiza la "única fuente de la verdad" sin confiar en el cliente.
+create or replace function public.set_sale_total_price()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_selling_price numeric;
+begin
+  select selling_price into v_selling_price
+  from activity_products
+  where id = new.product_id;
+
+  new.total_price := coalesce(v_selling_price, 0) * new.quantity;
+  return new;
+end;
+$$;
+
+create trigger trg_set_sale_total_price
+  before insert or update on activity_sales
+  for each row execute function public.set_sale_total_price();
+
+-- ------------------------------------------------------------
+-- 5. RLS — mismo patrón que el resto del esquema:
+--    SELECT/INSERT cualquier autenticado, UPDATE/DELETE solo admin.
+--    (Los miembros registran ventas; el admin gestiona inventario
+--    y gastos, y es el único que puede editar/eliminar.)
+-- ------------------------------------------------------------
+alter table activity_expenses enable row level security;
+alter table activity_products enable row level security;
+alter table activity_sales    enable row level security;
+
+-- activity_expenses
+create policy "activity_expenses_select_auth" on activity_expenses
+  for select to authenticated using (true);
+create policy "activity_expenses_insert_auth" on activity_expenses
+  for insert to authenticated with check (true);
+create policy "activity_expenses_update_admin" on activity_expenses
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "activity_expenses_delete_admin" on activity_expenses
+  for delete to authenticated using (public.is_admin());
+
+-- activity_products
+create policy "activity_products_select_auth" on activity_products
+  for select to authenticated using (true);
+create policy "activity_products_insert_auth" on activity_products
+  for insert to authenticated with check (true);
+create policy "activity_products_update_admin" on activity_products
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "activity_products_delete_admin" on activity_products
+  for delete to authenticated using (public.is_admin());
+
+-- activity_sales
+create policy "activity_sales_select_auth" on activity_sales
+  for select to authenticated using (true);
+create policy "activity_sales_insert_auth" on activity_sales
+  for insert to authenticated with check (true);
+create policy "activity_sales_update_admin" on activity_sales
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+create policy "activity_sales_delete_admin" on activity_sales
+  for delete to authenticated using (public.is_admin());
+
+-- ------------------------------------------------------------
+-- 6. Realtime — el dashboard del admin y el POS de los miembros
+--    se actualizan en vivo a medida que se registran ventas.
+-- ------------------------------------------------------------
+alter publication supabase_realtime add table activity_expenses;
+alter publication supabase_realtime add table activity_products;
+alter publication supabase_realtime add table activity_sales;

--- a/supabase/migrations/20260515000000_add_activity_status_and_committee_permissions.sql
+++ b/supabase/migrations/20260515000000_add_activity_status_and_committee_permissions.sql
@@ -1,0 +1,200 @@
+-- ============================================================
+-- FODAF — Actividades: estado + permisos por comité
+-- ============================================================
+-- Cambios:
+--   * `activities.status` (`in_progress` | `finished`) — controla
+--     si la actividad está abierta para edición o ya está cerrada.
+--   * `activities.finished_at` — fecha de cierre.
+--   * Helpers `is_activity_committee_member()` e
+--     `is_activity_editable()`.
+--   * RPCs `finish_activity()` / `reopen_activity()` para cambiar
+--     el estado sin abrir UPDATE sobre `activities` a no-admins.
+--   * RLS de gastos / productos / ventas pasa a delegar en
+--     `is_activity_editable()`: admin O miembro del comité,
+--     siempre que la actividad esté `in_progress`.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. Columnas nuevas en `activities`
+-- ------------------------------------------------------------
+alter table activities
+  add column status text not null default 'in_progress'
+    check (status in ('in_progress', 'finished'));
+
+alter table activities
+  add column finished_at timestamp with time zone;
+
+-- ------------------------------------------------------------
+-- 2. Helpers de permisos
+-- ------------------------------------------------------------
+
+-- `true` si el usuario autenticado pertenece al comité asignado
+-- a la actividad. Si la actividad no tiene comité, devuelve `false`.
+create or replace function public.is_activity_committee_member(p_activity_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from activities a
+    join team_members tm on tm.team_id = a.team_id
+    where a.id = p_activity_id
+      and tm.profile_id = auth.uid()
+  );
+$$;
+
+-- `true` si la actividad puede ser modificada por el usuario:
+-- admin (siempre que esté `in_progress`) o miembro del comité.
+-- Una actividad `finished` es read-only para todos hasta que
+-- el admin la reabra con `reopen_activity()`.
+create or replace function public.is_activity_editable(p_activity_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from activities a
+    where a.id = p_activity_id
+      and a.status = 'in_progress'
+      and (public.is_admin() or public.is_activity_committee_member(p_activity_id))
+  );
+$$;
+
+grant execute on function public.is_activity_committee_member(uuid) to authenticated;
+grant execute on function public.is_activity_editable(uuid) to authenticated;
+
+-- ------------------------------------------------------------
+-- 3. RPCs para cambiar el estado
+-- ------------------------------------------------------------
+
+-- Marca una actividad como finalizada. Solo admin o un miembro
+-- del comité asignado. Falla si ya está finalizada.
+create or replace function public.finish_activity(p_activity_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_status text;
+begin
+  select status into v_status from activities where id = p_activity_id;
+
+  if v_status is null then
+    raise exception 'La actividad no existe.';
+  end if;
+
+  if v_status = 'finished' then
+    raise exception 'La actividad ya está finalizada.';
+  end if;
+
+  if not (public.is_admin() or public.is_activity_committee_member(p_activity_id)) then
+    raise exception 'No tienes permiso para finalizar esta actividad.';
+  end if;
+
+  update activities
+  set status = 'finished',
+      finished_at = timezone('utc'::text, now())
+  where id = p_activity_id;
+end;
+$$;
+
+-- Reabre una actividad finalizada. Solo admin. Falla si ya está
+-- en curso.
+create or replace function public.reopen_activity(p_activity_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_status text;
+begin
+  if not public.is_admin() then
+    raise exception 'Solo un administrador puede reabrir una actividad.';
+  end if;
+
+  select status into v_status from activities where id = p_activity_id;
+
+  if v_status is null then
+    raise exception 'La actividad no existe.';
+  end if;
+
+  if v_status = 'in_progress' then
+    raise exception 'La actividad ya está en curso.';
+  end if;
+
+  update activities
+  set status = 'in_progress',
+      finished_at = null
+  where id = p_activity_id;
+end;
+$$;
+
+grant execute on function public.finish_activity(uuid) to authenticated;
+grant execute on function public.reopen_activity(uuid) to authenticated;
+
+-- ------------------------------------------------------------
+-- 4. RLS — escritura de gastos / productos / ventas pasa a
+--    delegar en `is_activity_editable()`. SELECT sigue abierto.
+-- ------------------------------------------------------------
+
+-- activity_expenses
+drop policy if exists "activity_expenses_insert_auth"  on activity_expenses;
+drop policy if exists "activity_expenses_update_admin" on activity_expenses;
+drop policy if exists "activity_expenses_delete_admin" on activity_expenses;
+
+create policy "activity_expenses_insert_editable" on activity_expenses
+  for insert to authenticated
+  with check (public.is_activity_editable(activity_id));
+
+create policy "activity_expenses_update_editable" on activity_expenses
+  for update to authenticated
+  using (public.is_activity_editable(activity_id))
+  with check (public.is_activity_editable(activity_id));
+
+create policy "activity_expenses_delete_editable" on activity_expenses
+  for delete to authenticated
+  using (public.is_activity_editable(activity_id));
+
+-- activity_products
+drop policy if exists "activity_products_insert_auth"  on activity_products;
+drop policy if exists "activity_products_update_admin" on activity_products;
+drop policy if exists "activity_products_delete_admin" on activity_products;
+
+create policy "activity_products_insert_editable" on activity_products
+  for insert to authenticated
+  with check (public.is_activity_editable(activity_id));
+
+create policy "activity_products_update_editable" on activity_products
+  for update to authenticated
+  using (public.is_activity_editable(activity_id))
+  with check (public.is_activity_editable(activity_id));
+
+create policy "activity_products_delete_editable" on activity_products
+  for delete to authenticated
+  using (public.is_activity_editable(activity_id));
+
+-- activity_sales
+drop policy if exists "activity_sales_insert_auth"  on activity_sales;
+drop policy if exists "activity_sales_update_admin" on activity_sales;
+drop policy if exists "activity_sales_delete_admin" on activity_sales;
+
+create policy "activity_sales_insert_editable" on activity_sales
+  for insert to authenticated
+  with check (public.is_activity_editable(activity_id));
+
+create policy "activity_sales_update_editable" on activity_sales
+  for update to authenticated
+  using (public.is_activity_editable(activity_id))
+  with check (public.is_activity_editable(activity_id));
+
+create policy "activity_sales_delete_editable" on activity_sales
+  for delete to authenticated
+  using (public.is_activity_editable(activity_id));

--- a/supabase/migrations/20260515010000_add_activity_start_at_and_scheduled.sql
+++ b/supabase/migrations/20260515010000_add_activity_start_at_and_scheduled.sql
@@ -1,0 +1,147 @@
+-- ============================================================
+-- FODAF — Actividades: hora de inicio y estado `scheduled`
+-- ============================================================
+-- Antes, las actividades nacían siempre `in_progress` desde el
+-- momento de la creación. Ahora se programa una hora de inicio
+-- y, hasta que esa hora se cumple, la actividad queda en estado
+-- `scheduled` (programada). Cuando llega el momento, pasa
+-- automáticamente a `in_progress` — la transición se calcula
+-- "on-read" con `effective_activity_status()`, sin necesidad de
+-- un cron.
+--
+-- `start_at` se agrega como nullable para no romper actividades
+-- previas creadas con la migración anterior; las nuevas son
+-- siempre con hora (validación en cliente).
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. Columna y nuevo valor de status
+-- ------------------------------------------------------------
+alter table activities add column start_at timestamp with time zone;
+
+alter table activities drop constraint activities_status_check;
+alter table activities add constraint activities_status_check
+  check (status in ('scheduled', 'in_progress', 'finished'));
+
+-- ------------------------------------------------------------
+-- 2. Estado efectivo: una `scheduled` cuyo `start_at` ya pasó
+--    se trata como `in_progress` para todos los efectos
+--    prácticos (permisos, listas, badges).
+-- ------------------------------------------------------------
+create or replace function public.effective_activity_status(
+  p_status text,
+  p_start_at timestamp with time zone
+)
+returns text
+language sql
+immutable
+set search_path = public
+as $$
+  select case
+    when p_status = 'scheduled' and (p_start_at is null or p_start_at <= now())
+      then 'in_progress'
+    else p_status
+  end;
+$$;
+
+grant execute on function public.effective_activity_status(text, timestamp with time zone) to authenticated;
+
+-- ------------------------------------------------------------
+-- 3. `is_activity_editable` usa el estado efectivo: admin o
+--    miembro del comité, y la actividad NO está `finished`.
+--    Una `scheduled` también es editable (el comité puede
+--    registrar gastos / inventario antes del evento).
+-- ------------------------------------------------------------
+create or replace function public.is_activity_editable(p_activity_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from activities a
+    where a.id = p_activity_id
+      and a.status <> 'finished'
+      and (public.is_admin() or public.is_activity_committee_member(p_activity_id))
+  );
+$$;
+
+-- ------------------------------------------------------------
+-- 4. `finish_activity` ahora acepta cerrar tanto una
+--    `scheduled` como una `in_progress` (el comité podría
+--    cancelar una actividad que ni siquiera arrancó).
+-- ------------------------------------------------------------
+create or replace function public.finish_activity(p_activity_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_status text;
+begin
+  select status into v_status from activities where id = p_activity_id;
+
+  if v_status is null then
+    raise exception 'La actividad no existe.';
+  end if;
+
+  if v_status = 'finished' then
+    raise exception 'La actividad ya está finalizada.';
+  end if;
+
+  if not (public.is_admin() or public.is_activity_committee_member(p_activity_id)) then
+    raise exception 'No tienes permiso para finalizar esta actividad.';
+  end if;
+
+  update activities
+  set status = 'finished',
+      finished_at = timezone('utc'::text, now())
+  where id = p_activity_id;
+end;
+$$;
+
+-- ------------------------------------------------------------
+-- 5. `reopen_activity` decide entre `scheduled` e
+--    `in_progress` según `start_at`: si la hora aún no llega,
+--    la actividad vuelve a estar programada; si ya pasó,
+--    arranca de inmediato.
+-- ------------------------------------------------------------
+create or replace function public.reopen_activity(p_activity_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_status text;
+  v_start_at timestamp with time zone;
+  v_new_status text;
+begin
+  if not public.is_admin() then
+    raise exception 'Solo un administrador puede reabrir una actividad.';
+  end if;
+
+  select status, start_at into v_status, v_start_at from activities where id = p_activity_id;
+
+  if v_status is null then
+    raise exception 'La actividad no existe.';
+  end if;
+
+  if v_status <> 'finished' then
+    raise exception 'La actividad no está finalizada.';
+  end if;
+
+  v_new_status := case
+    when v_start_at is not null and v_start_at > now() then 'scheduled'
+    else 'in_progress'
+  end;
+
+  update activities
+  set status = v_new_status,
+      finished_at = null
+  where id = p_activity_id;
+end;
+$$;

--- a/supabase/migrations/20260515020000_add_activity_sales_buyer_id.sql
+++ b/supabase/migrations/20260515020000_add_activity_sales_buyer_id.sql
@@ -1,0 +1,21 @@
+-- ============================================================
+-- FODAF — Actividades: comprador como referencia a `profiles`
+-- ============================================================
+-- Antes, `activity_sales.buyer_name` era texto libre. Ahora el
+-- POS prefiere atribuir la venta a un miembro del fondo:
+--   * `buyer_id` (FK a profiles) cuando el comprador es miembro.
+--   * `buyer_name` (texto libre) queda como respaldo para
+--     compradores externos (vecinos, invitados, etc.).
+-- Ambos son opcionales; ventas sin comprador identificado siguen
+-- siendo válidas. Solo se usa uno de los dos a la vez.
+-- ============================================================
+
+alter table activity_sales
+  add column buyer_id uuid references profiles(id) on delete set null;
+
+create index activity_sales_buyer_id_idx on activity_sales(buyer_id);
+
+-- Solo uno de los dos puede estar presente (o ninguno).
+alter table activity_sales
+  add constraint activity_sales_buyer_one_of
+  check (buyer_id is null or buyer_name is null);

--- a/types/database.ts
+++ b/types/database.ts
@@ -11,6 +11,7 @@ export type PenaltyReason = 'absence' | 'late_arrival' | 'other'
 export type PenaltyStatus = 'pending' | 'paid' | 'deducted_from_savings'
 export type WithdrawalStatus = 'pending' | 'approved' | 'rejected'
 export type InvestmentStatus = 'active' | 'completed'
+export type ActivityStatus = 'scheduled' | 'in_progress' | 'finished'
 
 // ---- Tables ----
 
@@ -68,8 +69,43 @@ export interface Activity {
   team_id: string | null
   name: string
   activity_date: string
-  costs: number
-  net_profits: number
+  /** Fecha y hora de inicio (timestamptz). Las actividades nuevas la requieren; las creadas antes de la migración pueden tener `null`. */
+  start_at: string | null
+  status: ActivityStatus
+  finished_at: string | null
+  created_at: string
+}
+
+export interface ActivityExpense {
+  id: string
+  activity_id: string
+  description: string
+  amount: number
+  created_at: string
+}
+
+export interface ActivityProduct {
+  id: string
+  activity_id: string
+  name: string
+  cost_price: number
+  selling_price: number
+  stock_quantity: number
+  created_at: string
+}
+
+export interface ActivitySale {
+  id: string
+  activity_id: string
+  seller_id: string
+  /** Comprador como miembro del fondo (FK a profiles). Mutuamente excluyente con `buyer_name`. */
+  buyer_id: string | null
+  /** Texto libre para compradores externos (vecinos, invitados). Mutuamente excluyente con `buyer_id`. */
+  buyer_name: string | null
+  product_id: string
+  quantity: number
+  /** Calculado por trigger: quantity * selling_price del producto. */
+  total_price: number
   created_at: string
 }
 
@@ -151,6 +187,9 @@ export interface Database {
   teams: Team
   team_members: TeamMember
   activities: Activity
+  activity_expenses: ActivityExpense
+  activity_products: ActivityProduct
+  activity_sales: ActivitySale
   meetings: Meeting
   penalties: Penalty
   withdrawals: Withdrawal

--- a/types/database.ts
+++ b/types/database.ts
@@ -114,26 +114,18 @@ export interface Investment {
  * Parámetros configurables del fondo, con histórico por año.
  * Los valores cambian según los estatutos; cada año tiene su
  * propia fila para preservar la integridad de cálculos pasados.
+ *
+ * Solo contiene los parámetros que el código consume; las reglas
+ * de estatutos sin lógica implementada no se parametrizan.
  */
 export interface FundSettings {
   year: number
 
-  // Ingreso y admisión
-  admission_fee: number
-  reentry_multiplier: number
-  enrollment_deadline_day: number
-  admission_exemption_year: number
-  legacy_member_cutoff_year: number
-
   // Ahorros
   min_savings_minor: number
   min_savings_adult: number
-  payment_deadline_day_january: number
-  payment_deadline_day_regular: number
 
   // Moras y sanciones
-  missed_installments_for_expulsion: number
-  loan_default_months_for_deduction: number
   penalty_absence: number
   penalty_late_arrival: number
 
@@ -142,9 +134,8 @@ export interface FundSettings {
   loan_limit_without_guarantor: number
   loan_savings_percentage_cap: number
 
-  // Cierre anual y junta
+  // Cierre anual
   year_end_base: number
-  board_min_seniority_years: number
 
   created_at: string
   updated_at: string

--- a/types/database.ts
+++ b/types/database.ts
@@ -110,6 +110,46 @@ export interface Investment {
   created_at: string
 }
 
+/**
+ * Parámetros configurables del fondo, con histórico por año.
+ * Los valores cambian según los estatutos; cada año tiene su
+ * propia fila para preservar la integridad de cálculos pasados.
+ */
+export interface FundSettings {
+  year: number
+
+  // Ingreso y admisión
+  admission_fee: number
+  reentry_multiplier: number
+  enrollment_deadline_day: number
+  admission_exemption_year: number
+  legacy_member_cutoff_year: number
+
+  // Ahorros
+  min_savings_minor: number
+  min_savings_adult: number
+  payment_deadline_day_january: number
+  payment_deadline_day_regular: number
+
+  // Moras y sanciones
+  missed_installments_for_expulsion: number
+  loan_default_months_for_deduction: number
+  penalty_absence: number
+  penalty_late_arrival: number
+
+  // Préstamos
+  min_interest_rate: number
+  loan_limit_without_guarantor: number
+  loan_savings_percentage_cap: number
+
+  // Cierre anual y junta
+  year_end_base: number
+  board_min_seniority_years: number
+
+  created_at: string
+  updated_at: string
+}
+
 // ---- Database schema map (útil para tipado genérico) ----
 
 export interface Database {
@@ -124,4 +164,5 @@ export interface Database {
   penalties: Penalty
   withdrawals: Withdrawal
   investments: Investment
+  fund_settings: FundSettings
 }


### PR DESCRIPTION
## Summary

Tres frentes en un solo PR (la rama empezó con los parámetros configurables y creció con el módulo de actividades en sesiones posteriores):

### 1. Estatutos 2026 y parámetros configurables del fondo
- Actualiza `/estatutos` con la versión modificada en la reunión de enero de 2026 y lista los 18 artículos individualmente.
- Nueva tabla `fund_settings` con **una fila por año** (PK `year`) para preservar el histórico de cuotas, multas, límites de préstamo y base de cierre anual.
- Composable `useFundSettings(year?)` con caché por año en estado global y fallback al año configurado más reciente.
- Nueva página `/admin/parametros` (selector de año + formulario por secciones) donde el admin crea/edita los parámetros.
- Reemplaza todos los valores hardcoded en `ContributionModal`, `PenaltyModal`, `prestamos/solicitar`, `admin/cierre-anual`, etc. por lecturas de `fund_settings`.
- CLAUDE.md documenta la convención: nunca hardcodear, siempre leer del composable.

### 2. POS de actividades (gastos, inventario, ventas)
- Nuevas tablas `activity_expenses`, `activity_products`, `activity_sales` con trigger `set_sale_total_price` que calcula `total_price = quantity * selling_price` en BD.
- Se eliminan `activities.costs` y `activities.net_profits`: los totales financieros se **derivan en tiempo real** de las filas hijas (única fuente de la verdad).
- Validación estricta de stock: una venta no puede superar `stock_quantity − unidades_ya_vendidas`.

### 3. Módulo unificado de actividades con ciclo de vida y permisos por comité
- **Una sola ruta `/actividades`** reemplaza `/admin/actividades` y `/actividades/[id]/vender`. El mismo detalle es el panel admin y el POS de los miembros, con UI condicional.
- **Ciclo de vida**: `scheduled → in_progress → finished`.
    - `start_at timestamptz` obligatorio al crear; el cliente decide el estado inicial según la hora.
    - Función SQL `effective_activity_status()` rebaja `scheduled` a `in_progress` cuando la hora cruza — sin cron, computado on-read. En el cliente, un reloj global tickea cada 30s para que los badges cambien en vivo.
    - RPCs `finish_activity()` (admin o comité) y `reopen_activity()` (solo admin, decide entre `scheduled` o `in_progress` según `start_at`).
- **Permisos por comité**:
    - Admin y miembros del comité asignado ven el detalle completo en `scheduled` e `in_progress`, pueden registrar gastos/inventario, finalizar.
    - Las ventas (POS) solo se habilitan cuando el estado efectivo es `in_progress` (la hora ya llegó).
    - Otros miembros ven la actividad con badge "Programada"/"En curso" pero no entran al detalle hasta que esté `finished`. Tras cerrar, todos ven el detalle en modo read-only.
- **RLS**: `is_activity_editable(activity_id)` centraliza la regla (admin o comité Y `status <> 'finished'`); las policies de gastos/productos/ventas delegan en ella. `activities` UPDATE sigue admin-only — el cambio de status pasa siempre por las RPCs.
- **Composable `useActivityPermissions`** expone `effectiveStatus`, `canViewDetail`, `canEdit`, `canSell`, `canFinalize`, `canReopen`.

### 4. UX del POS
- Botón "+ Nueva Venta" en la cabecera del detalle abre `ActivitySaleModal` (modo crear/editar).
- Comprador como **select de miembros** con opción "Otro" para externos (FK `buyer_id` a profiles + `buyer_name` libre, mutuamente excluyentes por CHECK).
- Edición y eliminación de ventas desde la tabla del detalle. La edición ajusta el stock disponible para no contar la propia venta como vendida.
- Productos sin stock se filtran del select (excepto el producto original cuando se edita).

### 5. Reporte PDF de la actividad
- Botón "Exportar PDF" en el detalle, visible solo para admin o comité cuando la actividad está `finished`.
- Generador `app/utils/activityReport.ts` con `jsPDF` + `jspdf-autotable`: banner emerald con nombre, metadatos (fecha+hora, comité, fecha de cierre), tres tarjetas de resumen financiero, tablas de gastos/inventario/ventas y footer con paginación.
- Abre el PDF en una nueva pestaña con `window.open(blobUrl)` para evitar el problema de `.crdownload` de Chrome Safe Browsing en dominios no-localhost.

### 6. Tooling
- `pnpm.onlyBuiltDependencies` + `pnpm-workspace.yaml` aprueban los build scripts de `@parcel/watcher`, `core-js` y `esbuild` que pnpm 11 ahora exige.

## Migrations (orden de aplicación)

1. `20260514000000_add_fund_settings.sql`
2. `20260514010000_drop_unused_fund_settings_columns.sql`
3. `20260514020000_add_activity_pos.sql`
4. `20260515000000_add_activity_status_and_committee_permissions.sql`
5. `20260515010000_add_activity_start_at_and_scheduled.sql`
6. `20260515020000_add_activity_sales_buyer_id.sql`
6. `20260515020000_add_activity_sales_buyer_id.sql`